### PR TITLE
chore: fix markdown lint + add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## What changed and why
+
+<!-- Brief description of the change. Link to relevant RFC/issue if applicable. -->
+
+## Type of change
+
+<!-- feat / fix / docs / refactor / test / chore -->
+
+## Checklist
+
+- [ ] CI is green
+- [ ] Reviewed with Jazz (pair review or async)
+- [ ] No architectural drift — aligned with MANIFESTO.md and relevant RFCs
+- [ ] Docs updated if user-facing behavior changed
+- [ ] Related spec/issue linked above (if applicable)

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -6,3 +6,4 @@ MD033: false  # Inline HTML — needed for MDX/Astro
 MD034: false  # Bare URLs — fine in RFCs and docs
 MD040: false  # Fenced code language — not always needed
 MD041: false  # First line heading — not always applicable
+MD060: false  # Table column style — our tables use compact separators


### PR DESCRIPTION
## What changed and why

- Disabled MD060 (table column style) in `.markdownlint.yml` — our compact table separators were triggering false positives
- Added `.github/pull_request_template.md` with project conventions checklist

## Type of change

chore

## Checklist

- [x] CI is green
- [x] No architectural drift — config-only + new template
- [x] Docs updated if user-facing behavior changed (N/A)
