### PR TITLE
fix: resolve golangci-lint errors

### DIFF
--- a/internal/client/client_coverage_test.go
+++ b/internal/client/client_coverage_test.go
@@ -96,10 +96,9 @@ func TestCloneSkill_AlreadyCloned(t *testing.T) {
 	c := New(ClientConfig{CacheDir: dir})
 	// pullRepo will fail (no real git repo) but that exercises the already-cloned path.
 	err := c.CloneSkill(repo, "")
-	if err == nil {
-		// If git is available and the pull somehow works, that's fine too.
-		// The point is we hit the already-cloned branch.
-	}
+	// If err == nil, git is available and the pull somehow works — that's fine too.
+	// The point is we hit the already-cloned branch.
+	_ = err
 }
 
 func TestCloneSkill_NoRemoteURL(t *testing.T) {

--- a/internal/debug/trace.go
+++ b/internal/debug/trace.go
@@ -115,7 +115,6 @@ func (r *RunTrace) WriteRaw(name string, suffix string, data []byte) {
 	if err := gz.Close(); err != nil {
 		slog.Error("debug: gzip close", "path", path, "error", err)
 	}
-	return
 }
 
 // WriteSkill writes a skill body to skills/<skillName>.md.

--- a/internal/extraction/logparser_coverage_test.go
+++ b/internal/extraction/logparser_coverage_test.go
@@ -11,9 +11,9 @@ func TestEstimateTokens(t *testing.T) {
 	}{
 		{nil, 0},
 		{[]byte(""), 0},
-		{[]byte("hello world!"), 3},   // 12 / 4
-		{[]byte("abcd"), 1},           // 4 / 4
-		{make([]byte, 1000), 250},     // 1000 / 4
+		{[]byte("hello world!"), 3}, // 12 / 4
+		{[]byte("abcd"), 1},         // 4 / 4
+		{make([]byte, 1000), 250},   // 1000 / 4
 	}
 	for _, tt := range tests {
 		got := EstimateTokens(tt.input)

--- a/internal/extraction/pipeline.go
+++ b/internal/extraction/pipeline.go
@@ -51,10 +51,10 @@ type Pipeline struct {
 	log        *slog.Logger
 	sampleRate float64 // 0.0–1.0, e.g. 0.01 for 1%
 	randIntn   RandIntn
-	committer  model.SkillCommitter // optional: pushes skills to git
-	scanner    *sanitize.Scanner    // optional: credential scanner
-	tracer     *debug.Tracer         // optional: pipeline debug tracing
-	extractor  string               // pipeline version identifier
+	committer  model.SkillCommitter    // optional: pushes skills to git
+	scanner    *sanitize.Scanner       // optional: credential scanner
+	tracer     *debug.Tracer           // optional: pipeline debug tracing
+	extractor  string                  // pipeline version identifier
 	extCfg     config.ExtractionConfig // extraction config for trace thresholds
 
 	// Stratified sampling counters: maintain ~50/50 extracted vs rejected.


### PR DESCRIPTION
Fix 4 lint failures on main:
- goimports formatting in pipeline.go and logparser_coverage_test.go
- Remove redundant return in trace.go (S1023)
- Remove empty branch in client_coverage_test.go (SA9003)