### PR TITLE
fix: API server always starts; serve exits on port conflict

### DIFF
--- a/cmd/kinoko/serve.go
+++ b/cmd/kinoko/serve.go
@@ -162,28 +162,28 @@ func runServe(cmd *cobra.Command, args []string) error {
 	if embCfgAPI.APIKey == "" {
 		embCfgAPI.APIKey = os.Getenv("OPENAI_API_KEY")
 	}
-	var apiSrv *api.Server
+	var apiEmbedder embedding.Embedder
 	if embCfgAPI.APIKey != "" {
-		apiEmbedder := embedding.New(embCfgAPI, logger)
-		apiPort := cfg.Server.GetAPIPort()
-		apiSrv = api.New(api.Config{
-			Host:     cfg.Server.Host,
-			Port:     apiPort,
-			Store:    store,
-			Embedder: apiEmbedder,
-			SSHURL:   connInfo.SSHUrl,
-			Logger:   logger,
-			Enqueue: func(ctx context.Context, session model.SessionRecord, logContent []byte) error {
-				return fmt.Errorf("extraction not available on server — use 'kinoko run' to process sessions")
-			},
-		})
-		if err := apiSrv.Start(); err != nil {
-			logger.Error("failed to start API server", "error", err)
-		} else {
-			logger.Info("API server ready", "port", apiPort)
-		}
+		apiEmbedder = embedding.New(embCfgAPI, logger)
 	} else {
-		logger.Warn("API server disabled: no embedding API key")
+		logger.Warn("No embedding API key — /discover will return 503")
+	}
+	apiPort := cfg.Server.GetAPIPort()
+	apiSrv := api.New(api.Config{
+		Host:     cfg.Server.Host,
+		Port:     apiPort,
+		Store:    store,
+		Embedder: apiEmbedder,
+		SSHURL:   connInfo.SSHUrl,
+		Logger:   logger,
+		Enqueue: func(ctx context.Context, session model.SessionRecord, logContent []byte) error {
+			return fmt.Errorf("extraction not available on server — use 'kinoko run' to process sessions")
+		},
+	})
+	if err := apiSrv.Start(); err != nil {
+		logger.Error("failed to start API server", "error", err)
+	} else {
+		logger.Info("API server ready", "port", apiPort)
 	}
 
 	// Wait for shutdown signal.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -185,6 +185,11 @@ func (s *Server) discover(w http.ResponseWriter, r *http.Request, prompt string,
 	}
 	ctx := r.Context()
 
+	if s.embedder == nil {
+		http.Error(w, `{"error":"embedding not configured — set KINOKO_EMBEDDING_API_KEY or OPENAI_API_KEY"}`, http.StatusServiceUnavailable)
+		return
+	}
+
 	// Embed the prompt
 	vec, err := s.embedder.Embed(ctx, prompt)
 	if err != nil {

--- a/internal/gitserver/server.go
+++ b/internal/gitserver/server.go
@@ -23,6 +23,7 @@ type Server struct {
 	config         *config.Config
 	dataDir        string
 	cmd            *exec.Cmd
+	cmdDone        chan error // result of cmd.Wait(), populated by Start
 	logger         *slog.Logger
 	softBinary     string
 	adminKeyPath   string
@@ -104,6 +105,7 @@ func (s *Server) Start() error {
 	s.cmd = exec.Command(s.softBinary, "serve") //nolint:gosec // controlled input from config
 	s.cmd.Env = env
 	s.cmd.Dir = s.dataDir
+	s.cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	// Start the server
 	if err := s.cmd.Start(); err != nil {
@@ -112,11 +114,17 @@ func (s *Server) Start() error {
 
 	s.logger.Info("Soft Serve process started", "pid", s.cmd.Process.Pid)
 
+	// Monitor subprocess in background (used by waitForReady and Stop).
+	s.cmdDone = make(chan error, 1)
+	go func() {
+		s.cmdDone <- s.cmd.Wait()
+	}()
+
 	// Wait for the server to be ready
 	if err := s.waitForReady(); err != nil {
-		// Kill the process if it's still running
+		// Kill the process group if it's still running
 		if s.cmd.Process != nil {
-			_ = s.cmd.Process.Kill()
+			_ = syscall.Kill(-s.cmd.Process.Pid, syscall.SIGKILL)
 		}
 		return fmt.Errorf("soft serve failed to start properly: %w", err)
 	}
@@ -128,18 +136,29 @@ func (s *Server) Start() error {
 	return nil
 }
 
-// waitForReady waits for Soft Serve to be ready by attempting SSH connections
+// waitForReady waits for Soft Serve to be ready by attempting SSH connections.
+// It also monitors the subprocess for early exit (e.g. port conflict).
 func (s *Server) waitForReady() error {
-	timeout := 30 * time.Second
+	timeout := 10 * time.Second
 	deadline := time.Now().Add(timeout)
 
 	for time.Now().Before(deadline) {
+		// Check if process already exited (port conflict, etc.).
+		select {
+		case err := <-s.cmdDone:
+			if err != nil {
+				return fmt.Errorf("soft serve exited early: %w", err)
+			}
+			return fmt.Errorf("soft serve exited early with status 0")
+		default:
+		}
+
 		// Try to connect via SSH to test if server is ready
 		testCmd := exec.Command("ssh", //nolint:gosec // controlled input from config
 			"-p", strconv.Itoa(s.config.Server.Port),
 			"-i", s.adminKeyPath,
 			"-o", "StrictHostKeyChecking=no",
-			"-o", "ConnectTimeout=5",
+			"-o", "ConnectTimeout=2",
 			s.config.Server.Host,
 			"repo", "list")
 
@@ -147,15 +166,14 @@ func (s *Server) waitForReady() error {
 			return nil // Server is ready
 		}
 
-		// Check if the process is still running
-		if s.cmd.ProcessState != nil && s.cmd.ProcessState.Exited() {
-			return fmt.Errorf("soft serve process exited unexpectedly")
-		}
-
-		time.Sleep(1 * time.Second)
+		time.Sleep(500 * time.Millisecond)
 	}
 
-	return fmt.Errorf("timeout waiting for server to be ready")
+	// Timed out — kill the process group.
+	if s.cmd.Process != nil {
+		_ = syscall.Kill(-s.cmd.Process.Pid, syscall.SIGKILL)
+	}
+	return fmt.Errorf("timeout after %s waiting for soft serve to be ready", timeout)
 }
 
 // Stop gracefully shuts down the git server
@@ -173,13 +191,8 @@ func (s *Server) Stop() error {
 	}
 
 	// Wait for graceful shutdown with timeout
-	done := make(chan error, 1)
-	go func() {
-		done <- s.cmd.Wait()
-	}()
-
 	select {
-	case <-done:
+	case <-s.cmdDone:
 		s.logger.Info("Git server stopped gracefully")
 	case <-time.After(10 * time.Second):
 		s.logger.Warn("Graceful shutdown timed out, sending SIGKILL")
@@ -187,7 +200,7 @@ func (s *Server) Stop() error {
 			s.logger.Error("Failed to kill process", "error", err)
 			return err
 		}
-		<-done // Wait for the process to actually exit
+		<-s.cmdDone // Wait for the process to actually exit
 		s.logger.Info("Git server stopped forcefully")
 	}
 


### PR DESCRIPTION
## Bug fixes

### Bug 1: API server gated on embedding API key
The API server (health, discover, ingest) was only created when an embedding API key was set. Now it always starts:
- `/health` always works
- `/discover` returns 503 when no embedder is configured
- `/ingest` already returned 501

### Bug 2: `kinoko serve` doesn't exit on port conflict
- `waitForReady` now monitors the subprocess via a shared `cmdDone` channel
- If Soft Serve exits early (port conflict), `Start()` returns an error immediately
- Timeout reduced from 30s to 10s
- Process group (`Setpgid`) used so we can kill the whole tree on timeout
- `Stop()` reuses the same `cmdDone` channel (no double `Wait()`)