### PR TITLE
ci: expand coverage tracking to include cmd/ and pkg/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,13 +60,13 @@ jobs:
         run: go vet ./...
 
       - name: Unit tests
-        run: go test -coverpkg=./internal/... -coverprofile=unit.cov ./internal/... -timeout 120s
+        run: go test -coverpkg=./internal/...,./cmd/...,./pkg/... -coverprofile=unit.cov ./internal/... -timeout 120s
 
       - name: Integration tests
-        run: go test -tags integration -coverpkg=./internal/... -coverprofile=integration.cov ./tests/integration/ -timeout 60s
+        run: go test -tags integration -coverpkg=./internal/...,./cmd/...,./pkg/... -coverprofile=integration.cov ./tests/integration/ -timeout 60s
 
       - name: E2E tests
-        run: go test -tags integration -coverpkg=./internal/... -coverprofile=e2e.cov ./tests/e2e/ -timeout 90s
+        run: go test -tags integration -coverpkg=./internal/...,./cmd/...,./pkg/... -coverprofile=e2e.cov ./tests/e2e/ -timeout 90s
 
       - name: Merge coverage
         run: |


### PR DESCRIPTION
## What

Expands `-coverpkg` in all three CI test steps from `./internal/...` to `./internal/...,./cmd/...,./pkg/...`.

## Why

We had code in `cmd/kinoko/` and `pkg/skill/` that was invisible to coverage reports. The old number only reflected `internal/` — honest metrics need to include everything.

## Local result

Unit + integration tests: **85.2%** combined coverage (e2e skipped locally due to soft-serve setup).

Fixes `internal-docs/bugs/coverage-incomplete.md`