### PR TITLE
fix: correct API port in quickstart (23232 → 23233)

### DIFF
--- a/site/src/content/docs/quickstart.mdx
+++ b/site/src/content/docs/quickstart.mdx
@@ -102,7 +102,7 @@ You should see a Soft Serve TUI or connection info. Press `q` to quit.
 You can also check the API:
 
 ```bash
-curl http://localhost:23232/api/v1/health
+curl http://localhost:23233/api/v1/health
 ```
 
 ## What You Have Now


### PR DESCRIPTION
## What changed and why

The quickstart docs had the health check curl example pointing at port 23232 (Soft Serve HTTP) instead of port 23233 (Kinoko API). Fixed the endpoint URL.

Scanned all docs under `site/src/content/docs/` — other references to 23232 correctly refer to Soft Serve HTTP.

## Type of change

fix / docs

## Checklist

- [x] CI is green
- [ ] Reviewed with Jazz (pair review or async)
- [x] No architectural drift — aligned with MANIFESTO.md and relevant RFCs
- [x] Docs updated if user-facing behavior changed
- [x] Related spec/issue linked above (if applicable)