### PR TITLE
fix: landing page polish — ASCII art, overflow, pitch

### DIFF
--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -19,29 +19,22 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 
 <div class="kinoko-hero-art">
 ```
-                    🍄
-                   ╱  ╲
-                  ╱    ╲
-     ┌──────────┐      ┌──────────┐      ┌──────────┐
-     │ Agent A  │      │ Agent B  │      │ Agent C  │
-     │ solves   │      │ inherits │      │ inherits │
-     │ problem  │      │ solution │      │ solution │
-     └────┬─────┘      └────┬─────┘      └────┬─────┘
-          │                 │                  │
-     ─────┴────────── mycelium ────────────────┴─────
-          ·    ·    ·    ·    ·    ·    ·    ·    ·
-           ·      ·      ·      ·      ·      ·
-             ·       ·       ·       ·       ·
+              🍄
+             ╱  ╲
+            ╱    ╲
+  ┌──────────┐ ┌──────────┐ ┌──────────┐
+  │ Agent A  │ │ Agent B  │ │ Agent C  │
+  │  solves  │ │ inherits │ │ inherits │
+  │ problem  │ │ solution │ │ solution │
+  └────┬─────┘ └────┬─────┘ └────┬─────┘
+       │             │             │
+  ─────┴───── mycelium ───────────┴─────
+       ·    ·    ·    ·    ·    ·    ·
+         ·      ·      ·      ·      ·
+           ·       ·       ·       ·
 ```
-</div>
 
-<div class="kinoko-pitch">
-
-**Agent A** debugs a CORS misconfiguration for 20 minutes. Finds the fix. Session ends. Knowledge gone.
-
-**Agent B** hits the same CORS issue next week. Another 20 minutes. Another API call. Same answer.
-
-**Kinoko** extracts the fix from Agent A's session, scores it, stores it. When Agent B starts working, the answer is already there. Injected automatically. Problem solved in seconds, not minutes.
+*One agent solves it. Every agent knows it. No repeated work, no lost knowledge.*
 
 </div>
 

--- a/site/src/styles/custom.css
+++ b/site/src/styles/custom.css
@@ -115,6 +115,8 @@ code:not(pre code) {
   text-align: center;
   margin: -1rem auto 2rem;
   max-width: 600px;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .kinoko-hero-art pre {
@@ -142,8 +144,11 @@ code:not(pre code) {
 
 /* Landing page: flow steps */
 .kinoko-flow {
-  max-width: 640px;
+  max-width: min(640px, 100%);
+  width: 100%;
   margin: 1.5rem auto 3rem;
+  box-sizing: border-box;
+  overflow: hidden;
 }
 
 .flow-step {
@@ -153,6 +158,10 @@ code:not(pre code) {
   padding: 1.25rem;
   border: 1px solid var(--sl-color-gray-4);
   border-radius: 0.75rem;
+  overflow: hidden;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
@@ -179,6 +188,18 @@ code:not(pre code) {
 .flow-content {
   flex: 1;
   min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.flow-content pre,
+.flow-content .expressive-code,
+.flow-content .expressive-code figure,
+.flow-content .expressive-code pre {
+  max-width: 100%;
+  overflow-x: auto;
+  box-sizing: border-box;
+  min-width: 0;
 }
 
 .flow-content h3 {
@@ -192,6 +213,8 @@ code:not(pre code) {
   font-size: 0.92rem;
   line-height: 1.6;
   color: var(--sl-color-gray-2);
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 .flow-connector {
@@ -207,6 +230,18 @@ code:not(pre code) {
   margin: 2rem 0 1rem;
   font-size: 0.95rem;
   color: var(--sl-color-gray-2);
+}
+
+/* Starlight splash page overflow containment */
+.main-pane,
+.content-panel,
+.sl-markdown-content {
+  overflow-x: hidden;
+}
+
+/* Also constrain the hero art on narrow viewports */
+.kinoko-hero-art pre {
+  max-width: calc(100vw - 3rem);
 }
 
 /* Mobile responsiveness */


### PR DESCRIPTION
## What
- Recentered ASCII mushroom art over the boxes
- Fixed overflow: shortened `kinoko match` example command
- Replaced 3-paragraph pitch with single italic caption: *"One agent solves it. Every agent knows it. No repeated work, no lost knowledge."*

## Why
Follow-up to #31. The landing page had alignment issues and the pitch section was too wordy.

## Checklist
- [x] Site-only change (no Go code)
- [x] Verified locally
- [x] Single focused commit