### PR TITLE
fix: goimports formatting in stage3_test.go

### DIFF
--- a/internal/extraction/stage3_test.go
+++ b/internal/extraction/stage3_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/kinoko-dev/kinoko/internal/model"
 )
 
-
 // --- Core Verdict Tests ---
 
 func TestStage3Critic(t *testing.T) {


### PR DESCRIPTION
## What
Fix goimports lint failure on main introduced by #30.

Extra blank line after imports in `stage3_test.go`.

## Checklist
- [x] `go vet ./...` clean
- [x] Single line deletion
- [x] Fixes CI on main