### PR TITLE
feat: animated hero diagram — connected vs disconnected agents

### DIFF
--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -41,8 +41,9 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
       <div class="hero-agent-tag hero-agent-tag--kinoko">kinoko</div>
     </div>
   </div>
-  <svg id="hero-paths-svg" class="hero-paths-svg"></svg>
   <div class="hero-underground" id="hero-underground">
+    <svg id="circuit-svg" class="circuit-svg"></svg>
+    <div class="hero-underground-soil"></div>
     <div class="hero-underground-dots" id="underground-dots"></div>
     <div class="hero-underground-label">mycelium network</div>
   </div>
@@ -98,56 +99,61 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
   const checkB = document.getElementById("check-b");
   const checkC = document.getElementById("check-c");
   const scene = document.getElementById("hero-scene");
-  const pathsSvg = document.getElementById("hero-paths-svg");
-  const agentB = document.getElementById("hero-agent-b");
-  const agentC = document.getElementById("hero-agent-c");
+  const circuitSvg = document.getElementById("circuit-svg");
   const underground = document.getElementById("hero-underground");
   if (!promptEl || !scene) return;
 
   let taskIdx = 0;
 
-  /* ── Circuit path helpers ── */
-  function getBottomCenter(el) {
-    const r = el.getBoundingClientRect();
-    const sr = scene.getBoundingClientRect();
-    return { x: r.left + r.width / 2 - sr.left, y: r.bottom - sr.top };
-  }
-  function getDotPos(idx) {
-    const dot = document.getElementById("src-dot-" + idx);
-    if (!dot) return { x: 0, y: 0 };
-    const r = dot.getBoundingClientRect();
-    const sr = scene.getBoundingClientRect();
-    return { x: r.left + r.width / 2 - sr.left, y: r.top + r.height / 2 - sr.top };
-  }
-  function rightAnglePath(from, to) {
-    /* from = underground dot, to = agent bottom center */
-    /* Route: go horizontal to align under target, then straight up */
-    const midY = from.y - (from.y - to.y) * 0.3;
-    return "M"+from.x+","+from.y+" L"+from.x+","+midY+" L"+to.x+","+midY+" L"+to.x+","+to.y;
-  }
-  function sizeSvg() {
-    const sr = scene.getBoundingClientRect();
-    pathsSvg.setAttribute("viewBox", "0 0 "+sr.width+" "+sr.height);
-    pathsSvg.style.width = sr.width + "px";
-    pathsSvg.style.height = sr.height + "px";
-  }
+  /* ── Circuit path helpers (split design: SVG inside underground + CSS roots on agents) ── */
+  const AGENT_TARGETS = [
+    { x: 0.5 },    /* Agent B: center of 2nd column */
+    { x: 5/6 },    /* Agent C: center of 3rd column */
+  ];
 
   let activeDot = null;
   function drawPaths() {
-    sizeSvg();
-    pathsSvg.innerHTML = "";
+    circuitSvg.innerHTML = "";
+    const ugW = underground.offsetWidth;
+    const ugH = underground.offsetHeight;
+
+    /* SVG viewBox matches underground dimensions */
+    circuitSvg.setAttribute("viewBox", "0 0 " + ugW + " " + ugH);
+
     const dotIdx = Math.floor(Math.random() * SOURCE_DOTS.length);
     activeDot = document.getElementById("src-dot-" + dotIdx);
     if (activeDot) activeDot.classList.add("source-dot--active");
 
-    const dotPos = getDotPos(dotIdx);
-    const bPos = getBottomCenter(agentB);
-    const cPos = getBottomCenter(agentC);
+    const dot = SOURCE_DOTS[dotIdx];
+    /* 30px buffer at top of underground — dots live in the bottom area */
+    const bufferPx = 30;
+    const dotAreaH = ugH - bufferPx;
+    const dotX = (dot.pctX / 100) * ugW;
+    const dotY = bufferPx + (dot.pctY / 100) * dotAreaH;
+
+    /* All horizontal routing happens inside the soil (below bufferPx).
+       Once a path reaches soil top (y=bufferPx), it only goes straight up. */
+    const soilTop = bufferPx;
+    const junctionY = soilTop + dotAreaH * 0.15;
+    /* Two routing lanes inside the soil, just above junction */
+    const lanes = [soilTop + dotAreaH * 0.05, soilTop + dotAreaH * 0.10];
 
     const ns = "http://www.w3.org/2000/svg";
-    [bPos, cPos].forEach((target, i) => {
+
+    AGENT_TARGETS.forEach((t, i) => {
+      const targetX = t.x * ugW;
+      const laneY = lanes[i];
+      /* midpoint X for zigzag — halfway between dot and target */
+      const midX = dotX + (targetX - dotX) * 0.5;
+
+      /* Path: dot → up to junction → horizontal to midX → up to lane → horizontal to targetX → up through buffer to top */
+      const d = "M"+dotX+","+dotY+
+                " L"+dotX+","+junctionY+
+                " L"+midX+","+junctionY+
+                " L"+midX+","+laneY+
+                " L"+targetX+","+laneY+
+                " L"+targetX+",0";
       const p = document.createElementNS(ns, "path");
-      const d = rightAnglePath(dotPos, target);
       p.setAttribute("d", d);
       p.setAttribute("fill", "none");
       p.setAttribute("stroke", "var(--sl-color-green)");
@@ -156,23 +162,23 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
       const len = p.getTotalLength ? p.getTotalLength() : 300;
       p.style.strokeDasharray = len;
       p.style.strokeDashoffset = len;
-      pathsSvg.appendChild(p);
-      /* stagger: B immediately, C after 300ms */
+      circuitSvg.appendChild(p);
       setTimeout(() => {
         p.style.transition = "stroke-dashoffset 0.7s ease-out";
         p.style.strokeDashoffset = "0";
       }, i * 300);
     });
+
+    /* activate CSS roots on agents */
   }
   function clearPaths() {
-    pathsSvg.querySelectorAll(".circuit-path").forEach(p => {
+    circuitSvg.querySelectorAll(".circuit-path").forEach(p => {
       p.style.transition = "opacity 0.4s";
       p.style.opacity = "0";
     });
     if (activeDot) { activeDot.classList.remove("source-dot--active"); activeDot = null; }
-    setTimeout(() => { pathsSvg.innerHTML = ""; }, 500);
+    setTimeout(() => { circuitSvg.innerHTML = ""; }, 500);
   }
-  window.addEventListener("resize", sizeSvg);
 
   function typeText(el, text, speed) {
     return new Promise(resolve => {

--- a/site/src/styles/custom.css
+++ b/site/src/styles/custom.css
@@ -153,10 +153,31 @@ code:not(pre code) {
   grid-template-columns: repeat(3, 1fr);
   gap: 0.75rem;
   margin-bottom: 0;
+  align-items: stretch;
   position: relative;
   z-index: 2;
   overflow: visible;
+  min-height: 8rem;
 }
+
+.hero-agents > .hero-agent {
+  margin-top: 0;
+}
+
+/* Kill Starlight's sibling margin rule inside the hero scene */
+.kinoko-hero-scene > * {
+  margin-top: 0 !important;
+}
+.kinoko-hero-scene > *:first-child {
+  margin-top: 0 !important;
+}
+.hero-agents {
+  margin-bottom: 0 !important;
+}
+.hero-underground {
+  margin-top: 0 !important;
+}
+
 
 .hero-agent {
   min-width: 0;
@@ -244,11 +265,12 @@ code:not(pre code) {
   box-shadow: 0 0 14px rgba(91, 140, 90, 0.2);
 }
 
-/* Circuit path overlay */
-.hero-paths-svg {
+/* Circuit path SVG inside underground */
+.circuit-svg {
   position: absolute;
-  top: 0;
-  left: 0;
+  inset: 0;
+  width: 100%;
+  height: 100%;
   pointer-events: none;
   z-index: 3;
   overflow: visible;
@@ -273,21 +295,36 @@ code:not(pre code) {
   50% { r: 4; }
 }
 
-/* Underground */
+/* Underground — extra 30px buffer on top (transparent) overlaps behind agents */
 .hero-underground {
   position: relative;
-  height: 80px;
-  margin-top: 0;
+  height: 110px;
+  margin-top: -30px !important;  /* slide up behind agents */
+  padding-top: 30px;             /* buffer zone — transparent, no content */
+  background: none;
+  overflow: visible;
+  z-index: 1;
+}
+
+/* Visible soil area (below the buffer) */
+.hero-underground-soil {
+  position: absolute;
+  top: 30px;
+  left: 0;
+  right: 0;
+  bottom: 0;
   background: linear-gradient(180deg, var(--sl-color-gray-5) 0%, #0d1a0d 100%);
   border-radius: 0 0 0.75rem 0.75rem;
   border: 1px solid var(--sl-color-gray-4);
   border-top: none;
-  overflow: visible;
 }
 
 .hero-underground-dots {
   position: absolute;
-  inset: 0;
+  top: 30px;    /* dots start below the buffer */
+  left: 0;
+  right: 0;
+  bottom: 0;
   overflow: hidden;
   border-radius: 0 0 0.75rem 0.75rem;
 }
@@ -461,6 +498,6 @@ code:not(pre code) {
   }
 
   .hero-underground {
-    height: 60px;
+    height: 90px;  /* 30px buffer + 60px content */
   }
 }


### PR DESCRIPTION
## What
Replaces the static ASCII mushroom art with an animated side-by-side comparison:

- **Left (Without Kinoko):** Agent A works alone, cycling through tasks — always takes hours 😩
- **Right (With Kinoko):** Agents B & C connected via animated mycelium with flowing dots and 🍄. First task slow, subsequent tasks reuse knowledge in minutes 🎉

### Animation
- Typing/backspace effect for task names
- Timer countup (fast for reuse, slow for first solve)
- SVG mycelium with flowing nutrient dots
- IntersectionObserver triggers on scroll
- Green glow celebration on fast solves

### Technical
- Pure HTML/CSS/JS, zero dependencies
- Responsive (stacks vertically on mobile)
- Dark theme compatible

## Checklist
- [x] Site-only change (2 files)
- [x] Mobile responsive
- [x] No caption needed — diagram is self-explanatory