### PR TITLE
fix: goimports formatting + gosec nolint

### DIFF
--- a/internal/api/sessions.go
+++ b/internal/api/sessions.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+
 	"github.com/kinoko-dev/kinoko/internal/model"
 )
 

--- a/internal/queue/session.go
+++ b/internal/queue/session.go
@@ -10,19 +10,19 @@ import (
 
 // SessionMetadata holds the lightweight session info stored client-side.
 type SessionMetadata struct {
-	SessionID        string
-	StartedAt        time.Time
-	EndedAt          time.Time
-	DurationMinutes  float64
-	ToolCallCount    int
-	ErrorCount       int
-	MessageCount     int
-	ErrorRate        float64
+	SessionID         string
+	StartedAt         time.Time
+	EndedAt           time.Time
+	DurationMinutes   float64
+	ToolCallCount     int
+	ErrorCount        int
+	MessageCount      int
+	ErrorRate         float64
 	HasSuccessfulExec bool
-	TokensUsed       int
-	AgentModel       string
-	UserID           string
-	LibraryID        string
+	TokensUsed        int
+	AgentModel        string
+	UserID            string
+	LibraryID         string
 }
 
 // GetSessionMetadata retrieves session metadata by ID.

--- a/internal/serverclient/client_test.go
+++ b/internal/serverclient/client_test.go
@@ -248,10 +248,10 @@ func TestGitPushCommitter_PathTraversal(t *testing.T) {
 	g := NewGitPushCommitter("git@example.com:repo.git", t.TempDir(), log)
 
 	cases := []struct {
-		name      string
-		library   string
-		skillID   string
-		wantErr   string
+		name    string
+		library string
+		skillID string
+		wantErr string
 	}{
 		{"dotdot library", "../etc", "skill-1", "invalid libraryID"},
 		{"slash library", "foo/bar", "skill-1", "invalid libraryID"},

--- a/internal/serverclient/commit.go
+++ b/internal/serverclient/commit.go
@@ -24,7 +24,7 @@ type GitPushCommitter struct {
 	dataDir string
 	log     *slog.Logger
 
-	mu    sync.Mutex            // protects repoMu map
+	mu     sync.Mutex             // protects repoMu map
 	repoMu map[string]*sync.Mutex // per-repo locks
 }
 
@@ -128,7 +128,7 @@ func (g *GitPushCommitter) ensureRepo(ctx context.Context, repoDir string) error
 	if err := os.MkdirAll(filepath.Dir(repoDir), 0o755); err != nil {
 		return err
 	}
-	cmd := exec.CommandContext(ctx, "git", "clone", g.sshURL, repoDir)
+	cmd := exec.CommandContext(ctx, "git", "clone", g.sshURL, repoDir) //nolint:gosec // sshURL is set at construction, not user input
 	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
 	out, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
Fixes lint failures after the client/server split (T1-T8).

## Changes
- `goimports` formatting on 4 files: `api/sessions.go`, `queue/session.go`, `serverclient/commit.go`, `serverclient/client_test.go`
- `//nolint:gosec` on `GitPushCommitter.clone()` — `sshURL` is set at construction time, not user input

## Verification
- `golangci-lint run ./...` — clean
- `go test -race -count=1 ./...` — 21/21 pass
- `go vet ./...` — clean