### PR TITLE
docs: fix Charis flag emoji in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ Keep it English only. No emoji in commit messages.
 | Implementation | Otso 🇫🇮 | Build from specs, branch + PR |
 | Code review | Jazz 👴 | Review every PR, grade B+ minimum to merge |
 | QA | Pavel 🇷🇺 | Test coverage, integration tests, verify on branch |
-| Docs | Charis 🇨🇧 | Update docs when behavior changes, audit regularly |
+| Docs | Charis 🇨🇦 | Update docs when behavior changes, audit regularly |
 | R&D | Luka 🇩🇰 | Research briefs, specs for new features |
 
 ### Review Process


### PR DESCRIPTION
Audited CONTRIBUTING.md against the codebase.

**Fix:** Charis flag emoji 🇨🇧 (invalid) → 🇨🇦 (Canada)

**Verified:**
- MANIFESTO.md reference exists ✓
- No stale file paths or broken code examples
- `go build ./cmd/kinoko && go vet ./...` pass ✓