### PR TITLE
docs: add GoDoc package headers and API endpoint comments

### DIFF
--- a/cmd/kinoko/main.go
+++ b/cmd/kinoko/main.go
@@ -1,3 +1,7 @@
+// Package main implements the kinoko CLI — the primary entry point for the
+// Kinoko knowledge-sharing infrastructure. Subcommands include serve (shared
+// infrastructure server), run (local agent daemon), extract (single-session
+// extraction), import (queue ingestion), and various management utilities.
 package main
 
 import (

--- a/internal/api/decay_api.go
+++ b/internal/api/decay_api.go
@@ -19,6 +19,8 @@ type UpdateDecayRequest struct {
 	DecayScore float64 `json:"decay_score"`
 }
 
+// handleListByDecay handles GET /api/v1/skills/decay.
+// Returns skills ordered by decay score, optionally filtered by library_id.
 func (s *Server) handleListByDecay(w http.ResponseWriter, r *http.Request) {
 	libraryID := r.URL.Query().Get("library_id")
 	limit := 100
@@ -40,6 +42,8 @@ func (s *Server) handleListByDecay(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, DecayListResponse{Skills: skills})
 }
 
+// handleUpdateDecay handles PATCH /api/v1/skills/{id}/decay.
+// Sets the decay score for a skill; score must be in [0.0, 1.0].
 func (s *Server) handleUpdateDecay(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if id == "" {

--- a/internal/api/embed.go
+++ b/internal/api/embed.go
@@ -28,6 +28,9 @@ func (s *Server) SetEmbedEngine(engine embedding.Engine) {
 	}
 }
 
+// handleEmbed handles POST /api/v1/embed.
+// Computes a vector embedding for the given text using the local ONNX engine.
+// Returns 503 if no engine is configured. Request bodies are limited to 1 MB.
 func (s *Server) handleEmbed(w http.ResponseWriter, r *http.Request) {
 	if s.embedEngine == nil {
 		http.Error(w, `{"error":"embedding engine not available"}`, http.StatusServiceUnavailable)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -138,6 +138,8 @@ func (s *Server) Addr() string {
 	return s.httpServer.Addr
 }
 
+// handleHealth handles GET /api/v1/health.
+// Returns {"status":"ok"} and, when available, a skill count from the store.
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	resp := HealthResponse{Status: "ok"}
 	// P1-8: Include skill count if store is available.
@@ -151,6 +153,11 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 
 // handleDiscoverGET removed - use POST /api/v1/discover instead
 
+// handleDiscover handles POST /api/v1/discover.
+// Accepts a DiscoverRequest with prompt, embedding, and/or patterns, queries
+// the skill store, and returns ranked SkillMatch results. If a prompt is
+// provided without an embedding, the server computes one via the configured
+// embedder. Concurrency is bounded by discoverSem.
 func (s *Server) handleDiscover(w http.ResponseWriter, r *http.Request) {
 	var req DiscoverRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -259,6 +266,10 @@ func (s *Server) discoverWithQuery(w http.ResponseWriter, r *http.Request, req D
 
 // Removed unused discover() method - replaced by unified handleDiscover
 
+// handleIngest handles POST /api/v1/ingest.
+// Accepts an IngestRequest containing a session ID and log content, creates a
+// session record in the store, and enqueues the log for extraction. Request
+// bodies are limited to 10 MB.
 func (s *Server) handleIngest(w http.ResponseWriter, r *http.Request) {
 	// P1-6: Limit request body to 10 MB to prevent memory exhaustion.
 	r.Body = http.MaxBytesReader(w, r.Body, 10<<20)

--- a/internal/model/domain.go
+++ b/internal/model/domain.go
@@ -1,3 +1,6 @@
+// Package model defines the core domain types and interfaces for the Kinoko
+// extraction and injection pipelines: skills, sessions, embeddings, queries,
+// and storage contracts.
 package model
 
 // ValidDomains is the set of recognised domains per spec §2.1.

--- a/internal/worker/config.go
+++ b/internal/worker/config.go
@@ -1,3 +1,7 @@
+// Package worker provides a concurrent worker pool and cron scheduler for
+// processing queued extraction sessions. The pool claims sessions from a
+// queue, runs the extraction pipeline, and records results. The scheduler
+// orchestrates periodic decay cycles and stale-session sweeps.
 package worker
 
 import "time"


### PR DESCRIPTION
## Summary

Adds missing GoDoc documentation across the codebase.

### Package-level docs (3 packages were missing)
- `cmd/kinoko` — main CLI entry point description
- `internal/model` — core domain types and interfaces
- `internal/worker` — worker pool and scheduler

### API endpoint documentation
Added handler-level doc comments for all 6 endpoints in `internal/api`:
- `GET /api/v1/health` — health check with optional skill count
- `POST /api/v1/discover` — skill discovery by prompt/embedding/patterns
- `POST /api/v1/embed` — local ONNX text embedding
- `POST /api/v1/ingest` — session log ingestion
- `GET /api/v1/skills/decay` — list skills by decay score
- `PATCH /api/v1/skills/{id}/decay` — update skill decay score

### Verification
- `go build ./cmd/kinoko` ✅
- `go vet ./...` ✅
- All existing exported types/functions already had doc comments