### PR TITLE
docs: add GoDoc package and function comments

### DIFF
--- a/internal/run/extraction/doc.go
+++ b/internal/run/extraction/doc.go
@@ -1,0 +1,6 @@
+// Package extraction implements the 3-stage skill extraction pipeline.
+// Stage 1 filters sessions by metadata heuristics, Stage 2 scores novelty
+// and rubric quality via embeddings and LLM, and Stage 3 applies an LLM
+// critic for final extract/reject verdicts. Extracted skills are persisted
+// as SKILL.md files with structured front matter.
+package extraction

--- a/internal/run/extraction/types.go
+++ b/internal/run/extraction/types.go
@@ -1,8 +1,3 @@
-// Package extraction implements the 3-stage skill extraction pipeline.
-// Stage 1 filters sessions by metadata heuristics, Stage 2 scores novelty
-// and rubric quality via embeddings and LLM, and Stage 3 applies an LLM
-// critic for final extract/reject verdicts. Extracted skills are persisted
-// as SKILL.md files with structured front matter.
 package extraction
 
 import (

--- a/internal/run/injection/client.go
+++ b/internal/run/injection/client.go
@@ -1,4 +1,3 @@
-// Package injection provides the skill injection client and prompt builder.
 package injection
 
 import (

--- a/internal/run/worker/doc.go
+++ b/internal/run/worker/doc.go
@@ -1,0 +1,5 @@
+// Package worker provides a background worker pool and periodic task scheduler
+// for the Kinoko run agent. The Pool claims queued sessions and runs them through
+// the extraction pipeline with configurable concurrency. The Scheduler manages
+// recurring jobs such as skill decay sweeps on a cron-like interval.
+package worker

--- a/pkg/model/doc.go
+++ b/pkg/model/doc.go
@@ -1,0 +1,5 @@
+// Package model defines the core domain types and interfaces for Kinoko.
+// It contains skill records, session metadata, extraction results, quality
+// scoring, and the store/embedder/extractor/injector contracts that the
+// run and serve subsystems implement.
+package model


### PR DESCRIPTION
Add or improve package-level GoDoc comments across the codebase.

## Changes

- **pkg/model**: New `doc.go` — documents the core domain types and interface contracts
- **internal/run/worker**: New `doc.go` — documents the worker pool and periodic scheduler
- **internal/run/extraction**: Moved package doc from `types.go` to dedicated `doc.go`
- **internal/run/injection**: Removed duplicate shorter package doc from `client.go` (kept the comprehensive version in `injector.go`)

## Already documented

The remaining priority packages already had good package-level doc comments:
`pkg/skill`, `internal/run/apiclient`, `internal/serve/api`, `internal/serve/storage`, `internal/serve/embedding`, `internal/serve/gitserver`, `internal/shared/config`, `internal/shared/decay`, `internal/shared/circuitbreaker`

Exported functions in `internal/serve/api` were also already well-documented.