### PR TITLE
docs: update site docs for restructured codebase

### DIFF
--- a/site/src/content/docs/concepts/architecture.mdx
+++ b/site/src/content/docs/concepts/architecture.mdx
@@ -155,7 +155,7 @@ A key architectural decision: **git is the source of truth**, everything else is
 - Skills have full version history, branching, and independent versioning
 
 This means:
-- `kinoko serve --reindex` rebuilds the entire index from git
+- `kinoko rebuild` rebuilds the entire index from git
 - No data loss if SQLite corrupts — git is the recovery path
 - Skills can be forked, overridden, and layered like Docker images
 

--- a/site/src/content/docs/concepts/extraction.mdx
+++ b/site/src/content/docs/concepts/extraction.mdx
@@ -60,7 +60,7 @@ This stage rejects the bulk of sessions instantly. A session that lasted 3 secon
 
 Two checks run in parallel:
 
-1. **Embedding novelty** — the session content is embedded and compared against existing skills via the server's novelty API (`POST /api/v1/novelty`). If the session is too similar to something already known (above the `novelty_threshold`, default 0.85), it's rejected as a duplicate.
+1. **Embedding novelty** — the session content is embedded and compared against existing skills via the server's discover API (`POST /api/v1/discover`). If the session is too similar to something already known (above the `novelty_threshold`, default 0.85), it's rejected as a duplicate.
 
 2. **LLM rubric scoring** — a lightweight LLM call scores the session across 7 quality dimensions (problem specificity, solution completeness, context portability, reasoning transparency, technical accuracy, verification evidence, innovation level). Sessions below threshold are rejected.
 

--- a/site/src/content/docs/concepts/injection.mdx
+++ b/site/src/content/docs/concepts/injection.mdx
@@ -50,13 +50,11 @@ Returns:
 {
   "skills": [
     {
-      "id": "fix-database-timeout", 
-      "name": "fix-database-timeout",
       "repo": "default",
-      "quality": 0.87, 
-      "similarity": 0.82,
-      "ssh_url": "ssh://localhost:23231/default.git",
-      "patterns": ["database", "timeout", "postgres"]
+      "name": "fix-database-timeout",
+      "description": "How to diagnose and fix database connection timeouts",
+      "score": 0.87,
+      "clone_url": "ssh://localhost:23231/default.git"
     }
   ]
 }
@@ -86,10 +84,10 @@ Matched skills are formatted as a prompt section and injected into the agent ses
 
 The following skills may be relevant to your current task.
 
-### fix-database-timeout (relevance: 0.87)
+### fix-database-timeout (score: 0.87)
 [Full SKILL.md content]
 
-### go-subprocess-management (relevance: 0.72)
+### go-subprocess-management (score: 0.72)
 [Full SKILL.md content]
 ```
 

--- a/site/src/content/docs/concepts/novelty.mdx
+++ b/site/src/content/docs/concepts/novelty.mdx
@@ -67,4 +67,4 @@ This two-pass approach means most duplicates are caught cheaply in Stage 2, and 
 
 ## API
 
-The novelty check is exposed as [`POST /api/v1/novelty`](/reference/api#post-apiv1novelty) for programmatic access. See the [API reference](/reference/api) for request/response formats.
+The novelty check is handled through the unified [`POST /api/v1/discover`](/reference/api#post-apiv1discover) endpoint. See the [API reference](/reference/api) for request/response formats.

--- a/site/src/content/docs/concepts/security.mdx
+++ b/site/src/content/docs/concepts/security.mdx
@@ -10,7 +10,7 @@ AI agents work with real credentials — API keys, tokens, passwords. When Kinok
 
 ## Credential Scanning
 
-Kinoko includes a built-in credential scanner (`internal/sanitize`) that detects **14 secret patterns** including:
+Kinoko includes a built-in credential scanner (`internal/run/sanitize`) that detects **14 secret patterns** including:
 
 - AWS access keys and secret keys
 - OpenAI / Anthropic / Google API keys

--- a/site/src/content/docs/reference/api.mdx
+++ b/site/src/content/docs/reference/api.mdx
@@ -67,13 +67,11 @@ Health check. Returns server status and skill count.
 {
   "skills": [
     {
-      "id": "postgres-query-optimization",
-      "name": "postgres-query-optimization", 
       "repo": "default",
-      "quality": 0.85,
-      "similarity": 0.72,
-      "ssh_url": "ssh://localhost:23231/default.git",
-      "patterns": ["postgres", "performance", "indexing"]
+      "name": "postgres-query-optimization",
+      "description": "Optimize PostgreSQL queries with proper indexing strategies",
+      "score": 0.85,
+      "clone_url": "ssh://localhost:23231/default.git"
     }
   ]
 }

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -17,13 +17,16 @@ AVAILABLE COMMANDS:
   serve     Start the Kinoko infrastructure server
   run       Start the local agent daemon
   extract   Run extraction pipeline on a session log file
+  import    Import session logs into the extraction queue
   ingest    Import a markdown file as a skill through the quality critic
   match     Find skills matching a query
   decay     Run one decay cycle
   scan      Scan files for credentials and secrets
   index     Index a skill repo into SQLite
   pull      Clone or update skill repositories
-  stats     Print pipeline metrics
+  queue     Queue inspection and management
+  rebuild   Rebuild SQLite cache from git repos
+  stats     Print client pipeline metrics
   help      Help about any command
 
 GLOBAL FLAGS:
@@ -277,6 +280,43 @@ kinoko ingest doc.md --name my-skill --library team-alpha
 
 ---
 
+## `kinoko import`
+
+Parse session log files and enqueue them for extraction. Does **not** start workers — sessions wait for `kinoko run` to process them.
+
+```bash
+kinoko import [path...] [flags]
+kinoko import --dir ./logs/
+```
+
+**Arguments:**
+
+| Argument | Description |
+|---|---|
+| `[path...]` | One or more session log file paths |
+
+**Flags:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--config` | string | `""` | Config file path |
+| `--library` | string | first configured | Library ID |
+| `--dir` | string | `""` | Directory of log files to import (`.log`, `.txt`, `.json`) |
+
+**Examples:**
+```bash
+kinoko import session.log
+kinoko import a.log b.log c.log
+kinoko import --dir ./logs/
+kinoko import --dir ./logs/ --library my-team
+```
+
+**Behavior:**
+- Files larger than 50 MB are skipped
+- Provide file paths as arguments, `--dir`, or both
+
+---
+
 ## `kinoko match`
 
 Query the Kinoko server for skills matching a text query. Useful for testing injection relevance or exploring the skill library.
@@ -456,9 +496,58 @@ kinoko pull --all                # Sync all cached skills
 
 ---
 
+## `kinoko queue`
+
+Queue inspection and management subcommands.
+
+```bash
+kinoko queue stats     # Print queue depth and status counts
+kinoko queue list      # List queued, pending, and errored sessions
+kinoko queue retry <session-id>  # Requeue a failed session
+kinoko queue flush     # Delete all queued sessions from the queue
+```
+
+**Subcommands:**
+
+| Subcommand | Description |
+|---|---|
+| `stats` | Print queue depth and status counts |
+| `list` | List queued, pending, and errored sessions |
+| `retry <session-id>` | Requeue a failed session for re-extraction |
+| `flush` | Delete all queued sessions from the queue |
+
+---
+
+## `kinoko rebuild`
+
+Rebuild the SQLite cache from git repos. Scans the repos directory for bare git repositories containing SKILL.md files, parses and indexes each one into SQLite.
+
+```bash
+kinoko rebuild [flags]
+```
+
+**Flags:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--clean` | bool | `false` | Drop skill tables before rebuilding |
+| `--library` | string | `""` | Only rebuild repos under this library prefix |
+| `--dsn` | string | `$KINOKO_STORAGE_DSN` | SQLite DSN |
+| `--api-url` | string | `$KINOKO_API_URL` or `http://127.0.0.1:23233` | Kinoko API URL |
+| `--data-dir` | string | `$SOFT_SERVE_DATA_PATH` or `~/.kinoko/data` | Soft Serve data directory |
+
+**Examples:**
+```bash
+kinoko rebuild
+kinoko rebuild --clean
+kinoko rebuild --library my-team --clean
+```
+
+---
+
 ## `kinoko stats`
 
-Query the database and print pipeline metrics.
+Query the database and print client pipeline metrics.
 
 ```bash
 kinoko stats [flags]

--- a/site/src/content/docs/reference/config.mdx
+++ b/site/src/content/docs/reference/config.mdx
@@ -20,7 +20,11 @@ The same config file is used by both `kinoko serve` (infrastructure) and `kinoko
 server:
   host: "127.0.0.1"
   port: 23231
+  apiPort: 0           # defaults to port+2
   dataDir: ~/.kinoko/data
+
+client:
+  queue_dsn: ~/.kinoko/queue.db
 
 storage:
   driver: sqlite
@@ -56,14 +60,21 @@ decay:
   deprecation_threshold: 0.05
   rescue_boost: 0.3
   rescue_window_days: 30
+  interval_hours: 6
 
 embedding:
   provider: openai
   model: text-embedding-3-small
   base_url: https://api.openai.com
+  api_key: ""
+  dims: 384
+  novelty_threshold: 0.85
 
 llm:
+  provider: openai
   model: gpt-4o-mini
+  api_key: ""
+  base_url: ""
 
 hooks:
   credential_scan: true
@@ -85,6 +96,7 @@ Controls the git server started by `kinoko serve`.
 |-------|------|---------|-------------|
 | `host` | string | `"127.0.0.1"` | IP to bind. Use `"0.0.0.0"` for all interfaces. |
 | `port` | int | `23231` | SSH port. Must be 1–65535. |
+| `apiPort` | int | `port+2` | HTTP API port. Defaults to `port+2` (port+1 is Soft Serve HTTP). |
 | `dataDir` | string | `~/.kinoko/data` | Directory for server data. Auto-created. |
 
 ### `storage`
@@ -93,6 +105,14 @@ Controls the git server started by `kinoko serve`.
 |-------|------|---------|-------------|
 | `driver` | string | `"sqlite"` | `"sqlite"` or `"postgres"` |
 | `dsn` | string | `~/.kinoko/kinoko.db` | Connection string. File path for SQLite, URL for Postgres. |
+
+### `client`
+
+Settings for `kinoko run` (client/daemon mode).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `queue_dsn` | string | `~/.kinoko/queue.db` | Path to the local extraction queue SQLite database. |
 
 ### `libraries`
 
@@ -142,6 +162,7 @@ Controls the 3-stage extraction pipeline.
 | `deprecation_threshold` | float | `0.05` | Score below which skills are deprecated |
 | `rescue_boost` | float | `0.3` | Boost for recently-used successful skills |
 | `rescue_window_days` | int | `30` | Window for rescue eligibility (days) |
+| `interval_hours` | int | `6` | Decay cycle interval in hours |
 
 ### `embedding`
 
@@ -150,12 +171,18 @@ Controls the 3-stage extraction pipeline.
 | `provider` | string | `"openai"` | Embedding provider |
 | `model` | string | `"text-embedding-3-small"` | Embedding model name |
 | `base_url` | string | `"https://api.openai.com"` | Base URL for API calls |
+| `api_key` | string | `""` | Provider API key (overridden by `KINOKO_EMBEDDING_API_KEY` env var) |
+| `dims` | int | `384` | Embedding dimensions |
+| `novelty_threshold` | float | `0.85` | Cosine similarity above which content is considered "too similar" |
 
 ### `llm`
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
+| `provider` | string | `"openai"` | LLM provider (`"openai"` or `"anthropic"`) |
 | `model` | string | `"gpt-4o-mini"` | LLM model name |
+| `api_key` | string | `""` | Provider API key (overridden by `KINOKO_LLM_API_KEY` env var) |
+| `base_url` | string | `""` | Optional base URL for proxies or custom endpoints |
 
 ### `hooks`
 
@@ -171,6 +198,13 @@ Controls the 3-stage extraction pipeline.
 |-------|------|---------|-------------|
 | `author` | string | `""` | Default author identifier |
 | `confidence` | float | `0.7` | Default confidence score (0.0–1.0) |
+
+### `debug`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `false` | Enable pipeline debug tracing |
+| `dir` | string | `""` | Directory for debug trace output |
 
 ## Environment Variables
 

--- a/site/src/content/docs/reference/embedding-engine.mdx
+++ b/site/src/content/docs/reference/embedding-engine.mdx
@@ -83,7 +83,7 @@ Used automatically when building without the `embedding` tag, and available for 
 
 ## Where It's Used
 
-- **[Novelty checking](/reference/api#post-apiv1novelty)** — embed candidate skills, compare against existing library
-- **[Skill matching](/reference/api#post-apiv1match)** — embed query context, find nearest-neighbor skills
+- **[Novelty checking](/reference/api#post-apiv1discover)** — embed candidate skills, compare against existing library
+- **[Skill matching](/reference/api#post-apiv1discover)** — embed query context, find nearest-neighbor skills
 - **[Embed endpoint](/reference/api#post-apiv1embed)** — expose embedding as an HTTP API
 - **Stage 2 extraction** — compute similarity scores during pipeline filtering


### PR DESCRIPTION
## Summary

Updates site documentation to reflect the codebase restructure.

### Path references fixed
- `internal/sanitize` → `internal/run/sanitize`

### Stale API endpoints fixed
- `POST /api/v1/novelty` → `POST /api/v1/discover` (consolidated)
- `POST /api/v1/match` → `POST /api/v1/discover` (consolidated)
- Fixed DiscoverResponse fields to match actual code (`score`, `clone_url`, `description`)
- Fixed stale anchor links in embedding-engine.mdx

### Stale CLI references fixed
- `kinoko serve --reindex` → `kinoko rebuild`

### Missing CLI commands documented
- `kinoko import` — enqueue session logs for extraction
- `kinoko queue` — queue inspection and management (stats, list, retry, flush)
- `kinoko rebuild` — rebuild SQLite cache from git repos

### Missing config sections/fields added
- `client` section (`queue_dsn`)
- `debug` section (`enabled`, `dir`)
- `server.apiPort`
- `embedding.api_key`, `embedding.dims`, `embedding.novelty_threshold`
- `llm.provider`, `llm.api_key`, `llm.base_url`
- `decay.interval_hours`

### Files changed
9 files across `site/src/content/docs/concepts/` and `site/src/content/docs/reference/`