### PR TITLE
test: improve debug trace coverage (T6)

### DIFF
--- a/internal/run/debug/trace_coverage_test.go
+++ b/internal/run/debug/trace_coverage_test.go
@@ -1,6 +1,9 @@
 package debug
 
 import (
+	"compress/gzip"
+	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -96,4 +99,98 @@ func TestWriteSummary_UnmarshalableData(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected no file for unmarshalable data")
 	}
+}
+
+func TestStartRun_ProcFakedir(t *testing.T) {
+	tr := NewTracer("/proc/fakedir")
+	rt := tr.StartRun()
+	if rt != nil {
+		t.Fatal("expected nil RunTrace for /proc/fakedir base dir")
+	}
+}
+
+func TestWriteRaw_ValidGzip(t *testing.T) {
+	tr := NewTracer(t.TempDir())
+	rt := tr.StartRun()
+	if rt == nil {
+		t.Fatal("expected non-nil RunTrace")
+	}
+
+	payload := []byte(`{"model":"gpt-4","prompt":"test"}`)
+	rt.WriteRaw("llm", "request", payload)
+
+	path := filepath.Join(rt.Dir, "llm.request.json.gz")
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("expected .gz file to exist: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Fatal("expected non-empty .gz file")
+	}
+
+	// Verify it's valid gzip with correct content.
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatalf("not valid gzip: %v", err)
+	}
+	defer gz.Close()
+
+	got, err := io.ReadAll(gz)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify JSON is intact.
+	var parsed map[string]string
+	if err := json.Unmarshal(got, &parsed); err != nil {
+		t.Fatalf("gzip content is not valid JSON: %v", err)
+	}
+	if parsed["model"] != "gpt-4" {
+		t.Fatalf("unexpected model: %s", parsed["model"])
+	}
+}
+
+func TestWriteSkill_ContentVerification(t *testing.T) {
+	tr := NewTracer(t.TempDir())
+	rt := tr.StartRun()
+	if rt == nil {
+		t.Fatal("expected non-nil RunTrace")
+	}
+
+	content := []byte("# My Skill\n\nThis skill does things.\n")
+	rt.WriteSkill("my-skill", content)
+
+	path := filepath.Join(rt.Dir, "skills", "my-skill.md")
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("expected skill file to exist: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("got %q, want %q", got, content)
+	}
+
+	// Verify permissions are 0600.
+	info, _ := os.Stat(path)
+	if info.Mode().Perm() != 0600 {
+		t.Fatalf("expected 0600 permissions, got %v", info.Mode().Perm())
+	}
+}
+
+func TestWriteSkill_BadDir(t *testing.T) {
+	// RunTrace with a directory that can't have subdirs created.
+	rt := &RunTrace{TraceID: "test", Dir: "/dev/null/impossible"}
+	// Should not panic.
+	rt.WriteSkill("skill1", []byte("content"))
+}
+
+func TestWriteRaw_BadDir(t *testing.T) {
+	rt := &RunTrace{TraceID: "test", Dir: "/dev/null/impossible"}
+	// Should not panic.
+	rt.WriteRaw("stage", "req", []byte("data"))
 }


### PR DESCRIPTION
## Coverage ticket T6

Added tests to `internal/run/debug/trace_coverage_test.go`:

- **`TestWriteRaw_ValidGzip`** — creates RunTrace, calls WriteRaw with JSON payload, verifies .gz file exists, is valid gzip, and JSON content is intact
- **`TestWriteSkill_ContentVerification`** — verifies skill file content and 0600 permissions
- **`TestStartRun_ProcFakedir`** — StartRun with `/proc/fakedir` returns nil
- **`TestWriteSkill_BadDir`** — WriteSkill with unwritable dir doesn't panic
- **`TestWriteRaw_BadDir`** — WriteRaw with unwritable dir doesn't panic

All 22 tests pass with `-race`.