### PR TITLE
fix: make TestWorkerPoolE2E deterministic

### DIFF
--- a/tests/integration/worker_integration_test.go
+++ b/tests/integration/worker_integration_test.go
@@ -509,6 +509,7 @@ func TestWorkerPoolE2E(t *testing.T) {
 
 	cfg := workerConfig()
 	cfg.Concurrency = 2
+	cfg.InitialBackoff = 30 * time.Second // Prevent retry within test deadline
 	queueStore, err := queue.New(filepath.Join(tmpDir, "queue.db"))
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Set InitialBackoff to 30s in TestWorkerPoolE2E so the failing session's retry is never triggered within the 5s test deadline.

Previously, with `Concurrency: 2` and `InitialBackoff: 1s`, a second worker could pick up the retried session, causing `TotalErrors` to be 2 instead of expected 1.