### PR TITLE
fix: remove embedding from stage2, rely on post-extraction novelty check

### DIFF
--- a/cmd/kinoko/extract.go
+++ b/cmd/kinoko/extract.go
@@ -115,18 +115,11 @@ func runExtract(cmd *cobra.Command, args []string) error {
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
-	// Server client for embeddings, skill querying, sessions, reviews.
+	// Server URL for novelty checking.
 	serverURL := cfg.ServerURL()
 	if extractAPIURL != "" {
 		serverURL = extractAPIURL
 	}
-	serverClient := apiclient.New(serverURL)
-
-	// Embedder via server HTTP API.
-	embedder := apiclient.NewHTTPEmbedder(serverClient, cfg.Embedding.GetDims())
-
-	// Skill querier via server HTTP API.
-	querier := apiclient.NewHTTPQuerier(serverClient)
 
 	// Initialize LLM client — Stage2 and Stage3 need it.
 	creds, err := llm.ResolveCredentials(cfg.LLM)
@@ -146,7 +139,7 @@ func runExtract(cmd *cobra.Command, args []string) error {
 
 	// Build pipeline stages
 	stage1 := extraction.NewStage1Filter(cfg.Extraction, logger)
-	stage2 := extraction.NewStage2Scorer(embedder, querier, llmClient, cfg.Extraction, logger)
+	stage2 := extraction.NewStage2Scorer(llmClient, cfg.Extraction, logger)
 	stage3 := extraction.NewStage3Critic(llmClient, cfg.Extraction, logger)
 
 	// Novelty checker via server API.

--- a/cmd/kinoko/workers_run.go
+++ b/cmd/kinoko/workers_run.go
@@ -34,12 +34,6 @@ func buildClientPipeline(cfg *config.Config, serverClient *apiclient.Client, log
 		return nil, nil
 	}
 
-	// Embedder via server HTTP API.
-	embedder := apiclient.NewHTTPEmbedder(serverClient, cfg.Embedding.GetDims())
-
-	// Skill querier via server HTTP API.
-	querier := apiclient.NewHTTPQuerier(serverClient)
-
 	// Use config model if set, otherwise use the model from credentials
 	llmModel := cfg.LLM.Model
 	if llmModel == "" {
@@ -51,7 +45,7 @@ func buildClientPipeline(cfg *config.Config, serverClient *apiclient.Client, log
 	}
 
 	stage1 := extraction.NewStage1Filter(cfg.Extraction, logger)
-	stage2 := extraction.NewStage2Scorer(embedder, querier, llmClient, cfg.Extraction, logger)
+	stage2 := extraction.NewStage2Scorer(llmClient, cfg.Extraction, logger)
 	stage3 := extraction.NewStage3Critic(llmClient, cfg.Extraction, logger)
 
 	// Git committer via SSH push.

--- a/internal/run/debug/trace.go
+++ b/internal/run/debug/trace.go
@@ -185,22 +185,14 @@ type FilterTrace struct {
 
 // Stage2Trace captures Stage 2 scoring results.
 type Stage2Trace struct {
-	Passed           bool               `json:"passed"`
-	EmbeddingNovelty *EmbeddingTrace    `json:"embedding_novelty,omitempty"`
-	RubricScores     map[string]float64 `json:"rubric_scores,omitempty"`
-	RubricAggregate  float64            `json:"rubric_aggregate"`
-	RubricThreshold  float64            `json:"rubric_threshold"`
-	Meta             *LLMMeta           `json:"meta,omitempty"`
-	RawRequestFile   string             `json:"raw_request_file,omitempty"`
-	RawResponseFile  string             `json:"raw_response_file,omitempty"`
-	DurationMs       int64              `json:"duration_ms"`
-}
-
-// EmbeddingTrace captures embedding novelty details.
-type EmbeddingTrace struct {
-	Distance     float64 `json:"distance"`
-	NearestSkill string  `json:"nearest_skill"`
-	Threshold    float64 `json:"threshold"`
+	Passed          bool               `json:"passed"`
+	RubricScores    map[string]float64 `json:"rubric_scores,omitempty"`
+	RubricAggregate float64            `json:"rubric_aggregate"`
+	RubricThreshold float64            `json:"rubric_threshold"`
+	Meta            *LLMMeta           `json:"meta,omitempty"`
+	RawRequestFile  string             `json:"raw_request_file,omitempty"`
+	RawResponseFile string             `json:"raw_response_file,omitempty"`
+	DurationMs      int64              `json:"duration_ms"`
 }
 
 // LLMMeta captures LLM call metadata.

--- a/internal/run/extraction/pipeline.go
+++ b/internal/run/extraction/pipeline.go
@@ -249,11 +249,6 @@ func (p *Pipeline) score(run *extractionRun) bool {
 
 	run.trace.WriteStage("stage2-scoring", debug.Stage2Trace{
 		Passed: s2.Passed,
-		EmbeddingNovelty: &debug.EmbeddingTrace{
-			Distance:     s2.EmbeddingDistance,
-			NearestSkill: s2.NearestSkillName,
-			Threshold:    p.extCfg.NoveltyMinDistance,
-		},
 		RubricScores: map[string]float64{
 			"problem_specificity":    float64(s2.RubricScores.ProblemSpecificity),
 			"solution_completeness":  float64(s2.RubricScores.SolutionCompleteness),

--- a/internal/run/extraction/stage2.go
+++ b/internal/run/extraction/stage2.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"math"
 
 	"github.com/kinoko-dev/kinoko/internal/run/llm"
 	"github.com/kinoko-dev/kinoko/internal/run/llmutil"
@@ -47,98 +46,32 @@ func init() {
 	}
 }
 
-// Stage2Scorer runs embedding novelty + structured rubric scoring.
+// Stage2Scorer runs structured rubric scoring.
 type Stage2Scorer interface {
 	Score(ctx context.Context, session model.SessionRecord, content []byte) (*model.Stage2Result, error)
 }
 
 type stage2Scorer struct {
-	embedder model.Embedder
-	querier  model.SkillQuerier
-	llm      llm.LLMClient
-	minDist  float64
-	maxDist  float64
-	log      *slog.Logger
+	llm llm.LLMClient
+	log *slog.Logger
 }
 
 // NewStage2Scorer creates a Stage2Scorer from dependencies and config.
 func NewStage2Scorer(
-	embedder model.Embedder,
-	querier model.SkillQuerier,
 	llmClient llm.LLMClient,
 	cfg config.ExtractionConfig,
 	log *slog.Logger,
 ) Stage2Scorer {
 	return &stage2Scorer{
-		embedder: embedder,
-		querier:  querier,
-		llm:      llmClient,
-		minDist:  cfg.NoveltyMinDistance,
-		maxDist:  cfg.NoveltyMaxDistance,
-		log:      log,
+		llm: llmClient,
+		log: log,
 	}
 }
 
 func (s *stage2Scorer) Score(ctx context.Context, session model.SessionRecord, content []byte) (*model.Stage2Result, error) {
 	result := &model.Stage2Result{}
 
-	// Classifier 1: Embedding Novelty
-	emb, err := s.embedder.Embed(ctx, string(content))
-	if err != nil {
-		return nil, fmt.Errorf("stage2: embed content: %w", err)
-	}
-
-	nearest, err := s.querier.QueryNearest(ctx, emb, session.LibraryID)
-	if err != nil {
-		return nil, fmt.Errorf("stage2: query skill store: %w", err)
-	}
-
-	var distance float64
-	if nearest == nil {
-		// No existing skills — maximum novelty.
-		distance = 1.0
-	} else {
-		// CosineSim is in [0,1] for normalized embeddings; distance = 1 - similarity.
-		distance = 1.0 - nearest.CosineSim
-	}
-
-	result.EmbeddingDistance = distance
-	if nearest != nil {
-		result.NearestSkillName = nearest.SkillName
-	}
-	// Novelty score: 0 at boundaries, 1 at midpoint of valid range.
-	if distance < s.minDist {
-		result.NoveltyScore = 0
-		result.Reason = fmt.Sprintf("too similar to existing skill (distance %.3f < min %.3f)", distance, s.minDist)
-		s.log.Info("stage2 reject: novelty too low", "session_id", session.ID, "distance", distance)
-		return result, nil
-	}
-	if distance > s.maxDist {
-		result.NoveltyScore = 0
-		result.Reason = fmt.Sprintf("too unrelated to existing skills (distance %.3f > max %.3f)", distance, s.maxDist)
-		s.log.Info("stage2 reject: novelty too high", "session_id", session.ID, "distance", distance)
-		return result, nil
-	}
-
-	// Normalize novelty into [0,1] within the valid range using a linear ramp
-	// from boundaries to midpoint (triangle function). Boundaries get a small
-	// epsilon floor so that edge-of-range sessions still carry a nonzero score.
-	mid := (s.minDist + s.maxDist) / 2
-	halfRange := (s.maxDist - s.minDist) / 2
-	if halfRange > 0 {
-		raw := 1.0 - math.Abs(distance-mid)/halfRange
-		// Floor at 0.05 so boundary distances are not zero.
-		if raw < 0.05 {
-			raw = 0.05
-		}
-		result.NoveltyScore = raw
-	} else {
-		result.NoveltyScore = 1.0
-	}
-
-	s.log.Info("stage2 novelty pass", "session_id", session.ID, "distance", distance, "novelty_score", result.NoveltyScore)
-
-	// Classifier 2: Structured Rubric Scoring via LLM
+	// Structured Rubric Scoring via LLM
 	prompt := buildRubricPrompt(content)
 	resp, err := s.llm.Complete(ctx, prompt)
 	if err != nil {

--- a/internal/run/extraction/stage2_test.go
+++ b/internal/run/extraction/stage2_test.go
@@ -15,36 +15,6 @@ import (
 
 // --- Mocks ---
 
-type mockEmbedder struct {
-	embedFn func(ctx context.Context, text string) ([]float32, error)
-}
-
-func (m *mockEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
-	return m.embedFn(ctx, text)
-}
-
-func (m *mockEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
-	var out [][]float32
-	for _, t := range texts {
-		v, err := m.embedFn(ctx, t)
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, v)
-	}
-	return out, nil
-}
-
-func (m *mockEmbedder) Dimensions() int { return 1536 }
-
-type mockQuerier struct {
-	queryFn func(ctx context.Context, embedding []float32, libraryID string) (*model.SkillQueryResult, error)
-}
-
-func (m *mockQuerier) QueryNearest(ctx context.Context, embedding []float32, libraryID string) (*model.SkillQueryResult, error) {
-	return m.queryFn(ctx, embedding, libraryID)
-}
-
 type mockLLM struct {
 	completeFn func(ctx context.Context, prompt string) (string, error)
 }
@@ -60,10 +30,7 @@ func testLogger() *slog.Logger {
 }
 
 func testConfig() config.ExtractionConfig {
-	return config.ExtractionConfig{
-		NoveltyMinDistance: 0.15,
-		NoveltyMaxDistance: 0.95,
-	}
+	return config.ExtractionConfig{}
 }
 
 func testSession() model.SessionRecord {
@@ -107,31 +74,6 @@ func failRubricJSON() string {
 	}`
 }
 
-// querierWithSimilarity returns a mock querier with the given cosine similarity.
-func querierWithSimilarity(sim float64) *mockQuerier {
-	return &mockQuerier{
-		queryFn: func(_ context.Context, _ []float32, _ string) (*model.SkillQueryResult, error) {
-			return &model.SkillQueryResult{CosineSim: sim}, nil
-		},
-	}
-}
-
-func emptyQuerier() *mockQuerier {
-	return &mockQuerier{
-		queryFn: func(_ context.Context, _ []float32, _ string) (*model.SkillQueryResult, error) {
-			return nil, nil
-		},
-	}
-}
-
-func okEmbedder() *mockEmbedder {
-	return &mockEmbedder{
-		embedFn: func(_ context.Context, _ string) ([]float32, error) {
-			return make([]float32, 1536), nil
-		},
-	}
-}
-
 func okLLM(json string) *mockLLM {
 	return &mockLLM{
 		completeFn: func(_ context.Context, _ string) (string, error) {
@@ -145,44 +87,13 @@ func okLLM(json string) *mockLLM {
 func TestStage2Scorer(t *testing.T) {
 	tests := []struct {
 		name        string
-		embedder    *mockEmbedder
-		querier     *mockQuerier
 		llm         *mockLLM
 		wantPassed  bool
 		wantErr     bool
 		checkResult func(t *testing.T, r *model.Stage2Result)
 	}{
 		{
-			name:       "novelty too low (too similar)",
-			embedder:   okEmbedder(),
-			querier:    querierWithSimilarity(0.90), // distance = 0.10 < 0.15
-			llm:        okLLM(goodRubricJSON()),
-			wantPassed: false,
-			checkResult: func(t *testing.T, r *model.Stage2Result) {
-				if r.EmbeddingDistance >= 0.15 {
-					t.Errorf("expected distance < 0.15, got %f", r.EmbeddingDistance)
-				}
-				if r.Reason == "" {
-					t.Error("expected rejection reason")
-				}
-			},
-		},
-		{
-			name:       "novelty too high (too unrelated)",
-			embedder:   okEmbedder(),
-			querier:    querierWithSimilarity(0.02), // distance = 0.98 > 0.95
-			llm:        okLLM(goodRubricJSON()),
-			wantPassed: false,
-			checkResult: func(t *testing.T, r *model.Stage2Result) {
-				if r.EmbeddingDistance <= 0.95 {
-					t.Errorf("expected distance > 0.95, got %f", r.EmbeddingDistance)
-				}
-			},
-		},
-		{
-			name:       "novelty in range but rubric fails",
-			embedder:   okEmbedder(),
-			querier:    querierWithSimilarity(0.50), // distance = 0.50, in range
+			name:       "rubric fails minimum viable",
 			llm:        okLLM(failRubricJSON()),
 			wantPassed: false,
 			checkResult: func(t *testing.T, r *model.Stage2Result) {
@@ -192,9 +103,7 @@ func TestStage2Scorer(t *testing.T) {
 			},
 		},
 		{
-			name:       "full pass",
-			embedder:   okEmbedder(),
-			querier:    querierWithSimilarity(0.50), // distance = 0.50
+			name:       "rubric passes",
 			llm:        okLLM(goodRubricJSON()),
 			wantPassed: true,
 			checkResult: func(t *testing.T, r *model.Stage2Result) {
@@ -207,27 +116,10 @@ func TestStage2Scorer(t *testing.T) {
 				if r.RubricScores.CompositeScore == 0 {
 					t.Error("expected non-zero composite score")
 				}
-				if r.NoveltyScore <= 0 {
-					t.Errorf("expected positive novelty score, got %f", r.NoveltyScore)
-				}
 			},
 		},
 		{
-			name:       "full pass with no existing skills",
-			embedder:   okEmbedder(),
-			querier:    emptyQuerier(),
-			llm:        okLLM(goodRubricJSON()),
-			wantPassed: false, // distance=1.0 > maxDist=0.95
-			checkResult: func(t *testing.T, r *model.Stage2Result) {
-				if r.EmbeddingDistance != 1.0 {
-					t.Errorf("expected distance 1.0, got %f", r.EmbeddingDistance)
-				}
-			},
-		},
-		{
-			name:     "LLM returns bad JSON",
-			embedder: okEmbedder(),
-			querier:  querierWithSimilarity(0.50),
+			name: "LLM returns bad JSON",
 			llm: &mockLLM{
 				completeFn: func(_ context.Context, _ string) (string, error) {
 					return "this is not json at all", nil
@@ -236,31 +128,7 @@ func TestStage2Scorer(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "embedder error",
-			embedder: &mockEmbedder{
-				embedFn: func(_ context.Context, _ string) ([]float32, error) {
-					return nil, errors.New("embedding service unavailable")
-				},
-			},
-			querier: querierWithSimilarity(0.50),
-			llm:     okLLM(goodRubricJSON()),
-			wantErr: true,
-		},
-		{
-			name:     "store error",
-			embedder: okEmbedder(),
-			querier: &mockQuerier{
-				queryFn: func(_ context.Context, _ []float32, _ string) (*model.SkillQueryResult, error) {
-					return nil, errors.New("db locked")
-				},
-			},
-			llm:     okLLM(goodRubricJSON()),
-			wantErr: true,
-		},
-		{
-			name:     "LLM error",
-			embedder: okEmbedder(),
-			querier:  querierWithSimilarity(0.50),
+			name: "LLM error",
 			llm: &mockLLM{
 				completeFn: func(_ context.Context, _ string) (string, error) {
 					return "", errors.New("rate limited")
@@ -270,29 +138,11 @@ func TestStage2Scorer(t *testing.T) {
 		},
 		{
 			name:       "LLM response wrapped in markdown code block",
-			embedder:   okEmbedder(),
-			querier:    querierWithSimilarity(0.50),
 			llm:        okLLM(fmt.Sprintf("```json\n%s\n```", goodRubricJSON())),
 			wantPassed: true,
 		},
 		{
-			name:       "boundary: distance exactly at min",
-			embedder:   okEmbedder(),
-			querier:    querierWithSimilarity(0.85), // distance = 0.15 == minDist
-			llm:        okLLM(goodRubricJSON()),
-			wantPassed: true,
-		},
-		{
-			name:       "boundary: distance exactly at max",
-			embedder:   okEmbedder(),
-			querier:    querierWithSimilarity(0.05), // distance = 0.95 == maxDist
-			llm:        okLLM(goodRubricJSON()),
-			wantPassed: true,
-		},
-		{
-			name:     "P1.1: out-of-range rubric scores rejected",
-			embedder: okEmbedder(),
-			querier:  querierWithSimilarity(0.50),
+			name: "out-of-range rubric scores rejected",
 			llm: okLLM(`{
 				"scores": {
 					"problem_specificity": 47,
@@ -309,9 +159,7 @@ func TestStage2Scorer(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:     "P1.1: zero score rejected",
-			embedder: okEmbedder(),
-			querier:  querierWithSimilarity(0.50),
+			name: "zero score rejected",
 			llm: okLLM(`{
 				"scores": {
 					"problem_specificity": 0,
@@ -328,9 +176,7 @@ func TestStage2Scorer(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:     "P1.1: negative score rejected",
-			embedder: okEmbedder(),
-			querier:  querierWithSimilarity(0.50),
+			name: "negative score rejected",
 			llm: okLLM(`{
 				"scores": {
 					"problem_specificity": 4,
@@ -347,9 +193,7 @@ func TestStage2Scorer(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:     "P1.2: invalid category defaults to tactical",
-			embedder: okEmbedder(),
-			querier:  querierWithSimilarity(0.50),
+			name: "invalid category defaults to tactical",
 			llm: okLLM(`{
 				"scores": {
 					"problem_specificity": 4,
@@ -371,9 +215,7 @@ func TestStage2Scorer(t *testing.T) {
 			},
 		},
 		{
-			name:     "P1.3: invalid patterns stripped",
-			embedder: okEmbedder(),
-			querier:  querierWithSimilarity(0.50),
+			name: "invalid patterns stripped",
 			llm: okLLM(`{
 				"scores": {
 					"problem_specificity": 4,
@@ -395,9 +237,7 @@ func TestStage2Scorer(t *testing.T) {
 			},
 		},
 		{
-			name:     "P1.3: all patterns invalid yields empty list",
-			embedder: okEmbedder(),
-			querier:  querierWithSimilarity(0.50),
+			name: "all patterns invalid yields empty list",
 			llm: okLLM(`{
 				"scores": {
 					"problem_specificity": 4,
@@ -419,40 +259,12 @@ func TestStage2Scorer(t *testing.T) {
 			},
 		},
 		{
-			name:       "P2.1: JSON with preamble containing braces",
-			embedder:   okEmbedder(),
-			querier:    querierWithSimilarity(0.50),
+			name:       "JSON with preamble containing braces",
 			llm:        okLLM(fmt.Sprintf("Here's my analysis:\n```json\n%s\n```", goodRubricJSON())),
 			wantPassed: true,
 		},
 		{
-			name:       "P2.2: novelty score at boundary is nonzero",
-			embedder:   okEmbedder(),
-			querier:    querierWithSimilarity(0.85), // distance = 0.15 = minDist
-			llm:        okLLM(goodRubricJSON()),
-			wantPassed: true,
-			checkResult: func(t *testing.T, r *model.Stage2Result) {
-				if r.NoveltyScore < 0.05 {
-					t.Errorf("expected novelty score >= 0.05 at boundary, got %f", r.NoveltyScore)
-				}
-			},
-		},
-		{
-			name:       "P2.2: novelty score at midpoint is 1.0",
-			embedder:   okEmbedder(),
-			querier:    querierWithSimilarity(0.45), // distance = 0.55 ≈ midpoint of [0.15, 0.95]
-			llm:        okLLM(goodRubricJSON()),
-			wantPassed: true,
-			checkResult: func(t *testing.T, r *model.Stage2Result) {
-				if r.NoveltyScore < 0.95 {
-					t.Errorf("expected novelty score near 1.0 at midpoint, got %f", r.NoveltyScore)
-				}
-			},
-		},
-		{
-			name:     "P2.3: composite score is weighted not flat average",
-			embedder: okEmbedder(),
-			querier:  querierWithSimilarity(0.50),
+			name: "composite score is weighted not flat average",
 			llm: okLLM(`{
 				"scores": {
 					"problem_specificity": 5,
@@ -480,7 +292,7 @@ func TestStage2Scorer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			scorer := NewStage2Scorer(tt.embedder, tt.querier, tt.llm, testConfig(), testLogger())
+			scorer := NewStage2Scorer(tt.llm, testConfig(), testLogger())
 			result, err := scorer.Score(context.Background(), testSession(), []byte("session content"))
 
 			if tt.wantErr {

--- a/internal/run/extraction/stage3_edge_test.go
+++ b/internal/run/extraction/stage3_edge_test.go
@@ -223,8 +223,8 @@ func TestStage3Critic_Stage2InputEdges(t *testing.T) {
 		name   string
 		stage2 *model.Stage2Result
 	}{
-		{"zero novelty score", &model.Stage2Result{
-			Passed: true, NoveltyScore: 0, EmbeddingDistance: 0.5,
+		{"basic rubric scores", &model.Stage2Result{
+			Passed: true,
 			RubricScores: model.QualityScores{
 				ProblemSpecificity: 3, SolutionCompleteness: 3, ContextPortability: 3,
 				ReasoningTransparency: 3, TechnicalAccuracy: 3, VerificationEvidence: 3,
@@ -233,7 +233,7 @@ func TestStage3Critic_Stage2InputEdges(t *testing.T) {
 			ClassifiedCategory: model.CategoryTactical,
 		}},
 		{"empty patterns", &model.Stage2Result{
-			Passed: true, NoveltyScore: 0.5, EmbeddingDistance: 0.5,
+			Passed: true,
 			RubricScores: model.QualityScores{
 				ProblemSpecificity: 3, SolutionCompleteness: 3, ContextPortability: 3,
 				ReasoningTransparency: 3, TechnicalAccuracy: 3, VerificationEvidence: 3,
@@ -242,7 +242,7 @@ func TestStage3Critic_Stage2InputEdges(t *testing.T) {
 			ClassifiedCategory: model.CategoryTactical, ClassifiedPatterns: []string{},
 		}},
 		{"max scores", &model.Stage2Result{
-			Passed: true, NoveltyScore: 1.0, EmbeddingDistance: 0.8,
+			Passed: true,
 			RubricScores: model.QualityScores{
 				ProblemSpecificity: 5, SolutionCompleteness: 5, ContextPortability: 5,
 				ReasoningTransparency: 5, TechnicalAccuracy: 5, VerificationEvidence: 5,
@@ -251,7 +251,7 @@ func TestStage3Critic_Stage2InputEdges(t *testing.T) {
 			ClassifiedCategory: model.CategoryFoundational, ClassifiedPatterns: []string{"BUILD/Backend/APIDesign"},
 		}},
 		{"min viable scores", &model.Stage2Result{
-			Passed: true, NoveltyScore: 0.05, EmbeddingDistance: 0.3,
+			Passed: true,
 			RubricScores: model.QualityScores{
 				ProblemSpecificity: 1, SolutionCompleteness: 1, ContextPortability: 1,
 				ReasoningTransparency: 1, TechnicalAccuracy: 1, VerificationEvidence: 1,

--- a/internal/run/extraction/stage3_helpers_test.go
+++ b/internal/run/extraction/stage3_helpers_test.go
@@ -69,7 +69,7 @@ func s3testSession() model.SessionRecord {
 
 func passingStage2() *model.Stage2Result {
 	return &model.Stage2Result{
-		Passed: true, EmbeddingDistance: 0.55, NoveltyScore: 0.85,
+		Passed: true,
 		RubricScores: model.QualityScores{
 			ProblemSpecificity: 4, SolutionCompleteness: 4, ContextPortability: 3,
 			ReasoningTransparency: 3, TechnicalAccuracy: 4, VerificationEvidence: 3,

--- a/internal/shared/config/config.go
+++ b/internal/shared/config/config.go
@@ -145,10 +145,6 @@ type ExtractionConfig struct {
 	MinToolCalls       int     `yaml:"min_tool_calls"`
 	MaxErrorRate       float64 `yaml:"max_error_rate"`
 
-	// Stage 2 thresholds
-	NoveltyMinDistance float64 `yaml:"novelty_min_distance"`
-	NoveltyMaxDistance float64 `yaml:"novelty_max_distance"`
-
 	// Version similarity threshold (Appendix A) — used in Phase 5+ for skill versioning.
 	VersionSimilarityThreshold float64 `yaml:"version_similarity_threshold"`
 
@@ -218,8 +214,6 @@ func DefaultConfig() *Config {
 			MinToolCalls:       3,
 			MaxErrorRate:       0.7,
 
-			NoveltyMinDistance:         0.15,
-			NoveltyMaxDistance:         0.95,
 			VersionSimilarityThreshold: 0.85,
 		},
 		Hooks: HooksConfig{
@@ -449,20 +443,8 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("extraction max_error_rate must be between 0.0 and 1.0, got %f", c.Extraction.MaxErrorRate)
 	}
 
-	if c.Extraction.NoveltyMinDistance < 0 || c.Extraction.NoveltyMinDistance > 1 {
-		return fmt.Errorf("extraction novelty_min_distance must be between 0.0 and 1.0, got %f", c.Extraction.NoveltyMinDistance)
-	}
-
-	if c.Extraction.NoveltyMaxDistance < 0 || c.Extraction.NoveltyMaxDistance > 1 {
-		return fmt.Errorf("extraction novelty_max_distance must be between 0.0 and 1.0, got %f", c.Extraction.NoveltyMaxDistance)
-	}
-
 	if c.Extraction.VersionSimilarityThreshold < 0 || c.Extraction.VersionSimilarityThreshold > 1 {
 		return fmt.Errorf("extraction version_similarity_threshold must be between 0.0 and 1.0, got %f", c.Extraction.VersionSimilarityThreshold)
-	}
-
-	if c.Extraction.NoveltyMinDistance > c.Extraction.NoveltyMaxDistance {
-		return fmt.Errorf("extraction novelty_min_distance (%f) > novelty_max_distance (%f)", c.Extraction.NoveltyMinDistance, c.Extraction.NoveltyMaxDistance)
 	}
 
 	// Validate defaults config

--- a/internal/shared/config/config_coverage_test.go
+++ b/internal/shared/config/config_coverage_test.go
@@ -135,31 +135,6 @@ func TestValidate_BadMaxErrorRate(t *testing.T) {
 	}
 }
 
-func TestValidate_BadNoveltyMin(t *testing.T) {
-	cfg := DefaultConfig()
-	cfg.Extraction.NoveltyMinDistance = -0.1
-	if err := cfg.Validate(); err == nil {
-		t.Fatal("expected error for negative novelty_min_distance")
-	}
-}
-
-func TestValidate_BadNoveltyMax(t *testing.T) {
-	cfg := DefaultConfig()
-	cfg.Extraction.NoveltyMaxDistance = 1.5
-	if err := cfg.Validate(); err == nil {
-		t.Fatal("expected error for novelty_max_distance > 1")
-	}
-}
-
-func TestValidate_NoveltyMinGtMax(t *testing.T) {
-	cfg := DefaultConfig()
-	cfg.Extraction.NoveltyMinDistance = 0.9
-	cfg.Extraction.NoveltyMaxDistance = 0.1
-	if err := cfg.Validate(); err == nil {
-		t.Fatal("expected error for novelty min > max")
-	}
-}
-
 func TestValidate_BadVersionSimilarity(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.Extraction.VersionSimilarityThreshold = -0.1

--- a/pkg/model/result.go
+++ b/pkg/model/result.go
@@ -26,12 +26,9 @@ type Stage1Result struct {
 	Reason          string `json:"reason,omitempty"`
 }
 
-// Stage2Result is the output of embedding + rubric scoring.
+// Stage2Result is the output of rubric scoring.
 type Stage2Result struct {
 	Passed             bool          `json:"passed"`
-	EmbeddingDistance  float64       `json:"embedding_distance"`
-	NearestSkillName   string        `json:"nearest_skill_name,omitempty"`
-	NoveltyScore       float64       `json:"novelty_score"`
 	RubricScores       QualityScores `json:"rubric_scores"`
 	ClassifiedCategory SkillCategory `json:"classified_category"`
 	ClassifiedPatterns []string      `json:"classified_patterns"`

--- a/site/src/content/docs/concepts/architecture.mdx
+++ b/site/src/content/docs/concepts/architecture.mdx
@@ -36,8 +36,8 @@ From agent session to injected knowledge:
            │ pass
            ▼
   ┌──────────────────────┐
-  │ Stage 2: embedding   │───reject──▶ discard
-  │ novelty + rubric     │
+  │ Stage 2: LLM rubric  │───reject──▶ discard
+  │ quality scoring      │
   └────────┬─────────────┘
            │ pass
            ▼

--- a/site/src/content/docs/concepts/extraction.mdx
+++ b/site/src/content/docs/concepts/extraction.mdx
@@ -54,17 +54,13 @@ Fast checks against session metadata — no content analysis needed:
 
 This stage rejects the bulk of sessions instantly. A session that lasted 3 seconds with zero tool calls isn't worth analyzing further.
 
-## Stage 2 — Embedding Novelty + Rubric Scoring
+## Stage 2 — LLM Rubric Scoring
 
-**Cost:** moderate (embedding + lightweight scoring). **Purpose:** filter noise and duplicates.
+**Cost:** moderate (one LLM call). **Purpose:** filter low-quality sessions before expensive extraction.
 
-Two checks run in parallel:
+An LLM call scores the session across 7 quality dimensions: problem specificity, solution completeness, context portability, reasoning transparency, technical accuracy, verification evidence, and innovation level. Sessions below the minimum viable threshold are rejected.
 
-1. **Embedding novelty** — the session content is embedded and compared against existing skills via the server's discover API (`POST /api/v1/discover`). If the session is too similar to something already known (above the `novelty_threshold`, default 0.85), it's rejected as a duplicate.
-
-2. **LLM rubric scoring** — a lightweight LLM call scores the session across 7 quality dimensions (problem specificity, solution completeness, context portability, reasoning transparency, technical accuracy, verification evidence, innovation level). Sessions below threshold are rejected.
-
-The novelty check is **fail-open**: if the server is unreachable, the session passes through. Better to extract a potential duplicate than lose novel knowledge.
+Stage 2 also classifies the session's category (foundational, tactical, contextual) and identifies matching patterns from the taxonomy.
 
 ## Stage 3 — Combined Critic + SKILL.md Generation
 

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -228,7 +228,7 @@ kinoko extract <session-log> [flags]
 
 1. **Parse** — reads the session log and extracts metadata
 2. **Stage 1 (Filter)** — fast heuristic check, rejects trivial sessions
-3. **Stage 2 (Scorer)** — embedding similarity + LLM scoring for novelty and quality
+3. **Stage 2 (Scorer) — LLM rubric scoring for quality assessment
 4. **Stage 3 (Critic)** — LLM evaluates the candidate skill (substitution test, hard reject triggers, SKILL.md generation)
 5. **Novelty check** — queries the server to ensure the skill isn't a duplicate
 6. **Git push** — commits the skill to the library (skipped with `--dry-run`)

--- a/site/src/content/docs/reference/config.mdx
+++ b/site/src/content/docs/reference/config.mdx
@@ -44,8 +44,6 @@ extraction:
   max_duration_minutes: 180
   min_tool_calls: 3
   max_error_rate: 0.7
-  novelty_min_distance: 0.15
-  novelty_max_distance: 0.95
   version_similarity_threshold: 0.85
   sample_rate: 0.01
   ab_test:
@@ -139,8 +137,6 @@ Controls the 3-stage extraction pipeline.
 | `max_duration_minutes` | float | `180` | Stage 1: maximum session duration |
 | `min_tool_calls` | int | `3` | Stage 1: minimum tool call count |
 | `max_error_rate` | float | `0.7` | Stage 1: maximum error rate (0.0–1.0) |
-| `novelty_min_distance` | float | `0.15` | Stage 2: minimum embedding distance for novelty |
-| `novelty_max_distance` | float | `0.95` | Stage 2: maximum embedding distance |
 | `version_similarity_threshold` | float | `0.85` | Threshold for skill versioning |
 | `sample_rate` | float | `0.01` | Human review sample rate (0.0–1.0) |
 

--- a/site/src/content/docs/reference/embedding-engine.mdx
+++ b/site/src/content/docs/reference/embedding-engine.mdx
@@ -86,4 +86,4 @@ Used automatically when building without the `embedding` tag, and available for 
 - **[Novelty checking](/reference/api#post-apiv1discover)** — embed candidate skills, compare against existing library
 - **[Skill matching](/reference/api#post-apiv1discover)** — embed query context, find nearest-neighbor skills
 - **[Embed endpoint](/reference/api#post-apiv1embed)** — expose embedding as an HTTP API
-- **Stage 2 extraction** — compute similarity scores during pipeline filtering
+- **Post-extraction novelty — compare extracted skills against existing ones

--- a/tests/integration/concurrent_flow_test.go
+++ b/tests/integration/concurrent_flow_test.go
@@ -43,10 +43,9 @@ func TestConcurrentExtractionAndInjection(t *testing.T) {
 
 	for i := 0; i < n; i++ {
 		go func(idx int) {
-			emb := newPredictableEmbedder(3)
 			llm := &predictableLLM{rubricResponse: goodRubricJSON(), criticResponse: extractVerdictJSON()}
 			s1 := extraction.NewStage1Filter(defaultExtractionConfig(), testLogger())
-			s2 := extraction.NewStage2Scorer(emb, &mockQuerier{sim: 0.5}, llm, defaultExtractionConfig(), testLogger())
+			s2 := extraction.NewStage2Scorer(llm, defaultExtractionConfig(), testLogger())
 			s3 := extraction.NewStage3Critic(llm, defaultExtractionConfig(), testLogger())
 			p, _ := extraction.NewPipeline(extraction.PipelineConfig{
 				Stage1: s1, Stage2: s2, Stage3: s3, Committer: noopCommitter{}, Log: testLogger(),

--- a/tests/integration/crossgate_test.go
+++ b/tests/integration/crossgate_test.go
@@ -42,7 +42,7 @@ func TestG1G2_CredentialRedactionBeforeCommit(t *testing.T) {
 	}
 
 	s1 := extraction.NewStage1Filter(defaultExtractionConfig(), testLogger())
-	s2 := extraction.NewStage2Scorer(embedder, &mockQuerier{sim: 0.5}, llm, defaultExtractionConfig(), testLogger())
+	s2 := extraction.NewStage2Scorer(llm, defaultExtractionConfig(), testLogger())
 	s3 := extraction.NewStage3Critic(llm, defaultExtractionConfig(), testLogger())
 
 	// Track what gets committed.
@@ -181,7 +181,7 @@ func TestG1G3_ExtractDiscoverClone(t *testing.T) {
 	}
 
 	s1 := extraction.NewStage1Filter(defaultExtractionConfig(), testLogger())
-	s2 := extraction.NewStage2Scorer(embedder, &mockQuerier{sim: 0.5}, llm, defaultExtractionConfig(), testLogger())
+	s2 := extraction.NewStage2Scorer(llm, defaultExtractionConfig(), testLogger())
 	s3 := extraction.NewStage3Critic(llm, defaultExtractionConfig(), testLogger())
 
 	indexer := storage.NewSQLiteIndexer(store)
@@ -257,7 +257,7 @@ func TestFullPipeline_SessionToClientDiscovery(t *testing.T) {
 	}
 
 	s1 := extraction.NewStage1Filter(defaultExtractionConfig(), testLogger())
-	s2 := extraction.NewStage2Scorer(embedder, &mockQuerier{sim: 0.5}, llm, defaultExtractionConfig(), testLogger())
+	s2 := extraction.NewStage2Scorer(llm, defaultExtractionConfig(), testLogger())
 	s3 := extraction.NewStage3Critic(llm, defaultExtractionConfig(), testLogger())
 
 	indexer := storage.NewSQLiteIndexer(store)
@@ -318,7 +318,6 @@ Tests passed. Solution verified.`
 func TestEdge_EmptySessionLog(t *testing.T) {
 	_ = newTestStore(t)
 	ctx := context.Background()
-	embedder := newPredictableEmbedder(3)
 
 	llm := &predictableLLM{
 		rubricResponse: goodRubricJSON(),
@@ -326,7 +325,7 @@ func TestEdge_EmptySessionLog(t *testing.T) {
 	}
 
 	s1 := extraction.NewStage1Filter(defaultExtractionConfig(), testLogger())
-	s2 := extraction.NewStage2Scorer(embedder, &mockQuerier{sim: 0.5}, llm, defaultExtractionConfig(), testLogger())
+	s2 := extraction.NewStage2Scorer(llm, defaultExtractionConfig(), testLogger())
 	s3 := extraction.NewStage3Critic(llm, defaultExtractionConfig(), testLogger())
 
 	pipeline, _ := extraction.NewPipeline(extraction.PipelineConfig{
@@ -369,7 +368,6 @@ postgres://root:pass@db:5432/prod`
 	// Feed redacted content through extraction — should reject.
 	_ = newTestStore(t)
 	ctx := context.Background()
-	embedder := newPredictableEmbedder(3)
 
 	llm := &predictableLLM{
 		rubricResponse: goodRubricJSON(),
@@ -377,7 +375,7 @@ postgres://root:pass@db:5432/prod`
 	}
 
 	s1 := extraction.NewStage1Filter(defaultExtractionConfig(), testLogger())
-	s2 := extraction.NewStage2Scorer(embedder, &mockQuerier{sim: 0.5}, llm, defaultExtractionConfig(), testLogger())
+	s2 := extraction.NewStage2Scorer(llm, defaultExtractionConfig(), testLogger())
 	s3 := extraction.NewStage3Critic(llm, defaultExtractionConfig(), testLogger())
 
 	pipeline, _ := extraction.NewPipeline(extraction.PipelineConfig{
@@ -429,7 +427,7 @@ func TestEdge_ConcurrentSameSkillExtraction(t *testing.T) {
 				criticResponse: extractVerdictJSON(),
 			}
 			s1 := extraction.NewStage1Filter(defaultExtractionConfig(), testLogger())
-			s2 := extraction.NewStage2Scorer(embedder, &mockQuerier{sim: 0.5}, llm, defaultExtractionConfig(), testLogger())
+			s2 := extraction.NewStage2Scorer(llm, defaultExtractionConfig(), testLogger())
 			s3 := extraction.NewStage3Critic(llm, defaultExtractionConfig(), testLogger())
 			pipeline, _ := extraction.NewPipeline(extraction.PipelineConfig{
 				Stage1: s1, Stage2: s2, Stage3: s3,
@@ -477,7 +475,6 @@ func TestEdge_LargeSessionLog(t *testing.T) {
 
 	_ = newTestStore(t)
 	ctx := context.Background()
-	embedder := newPredictableEmbedder(3)
 
 	llm := &predictableLLM{
 		rubricResponse: goodRubricJSON(),
@@ -485,7 +482,7 @@ func TestEdge_LargeSessionLog(t *testing.T) {
 	}
 
 	s1 := extraction.NewStage1Filter(defaultExtractionConfig(), testLogger())
-	s2 := extraction.NewStage2Scorer(embedder, &mockQuerier{sim: 0.5}, llm, defaultExtractionConfig(), testLogger())
+	s2 := extraction.NewStage2Scorer(llm, defaultExtractionConfig(), testLogger())
 	s3 := extraction.NewStage3Critic(llm, defaultExtractionConfig(), testLogger())
 
 	pipeline, _ := extraction.NewPipeline(extraction.PipelineConfig{

--- a/tests/integration/extraction_flow_test.go
+++ b/tests/integration/extraction_flow_test.go
@@ -25,7 +25,7 @@ func TestFullExtractionFlow(t *testing.T) {
 	reviewer := &mockReviewWriter{}
 
 	s1 := extraction.NewStage1Filter(defaultExtractionConfig(), testLogger())
-	s2 := extraction.NewStage2Scorer(embedder, &mockQuerier{sim: 0.50}, llm, defaultExtractionConfig(), testLogger())
+	s2 := extraction.NewStage2Scorer(llm, defaultExtractionConfig(), testLogger())
 	s3 := extraction.NewStage3Critic(llm, defaultExtractionConfig(), testLogger())
 
 	indexer := storage.NewSQLiteIndexer(store)
@@ -114,9 +114,8 @@ func TestRejectionFlows(t *testing.T) {
 		ctx := context.Background()
 
 		s1 := extraction.NewStage1Filter(defaultExtractionConfig(), testLogger())
-		embedder := newPredictableEmbedder(3)
 		llm := &predictableLLM{rubricResponse: goodRubricJSON(), criticResponse: extractVerdictJSON()}
-		s2 := extraction.NewStage2Scorer(embedder, &mockQuerier{sim: 0.5}, llm, defaultExtractionConfig(), testLogger())
+		s2 := extraction.NewStage2Scorer(llm, defaultExtractionConfig(), testLogger())
 		s3 := extraction.NewStage3Critic(llm, defaultExtractionConfig(), testLogger())
 
 		pipeline, _ := extraction.NewPipeline(extraction.PipelineConfig{
@@ -152,14 +151,13 @@ func TestRejectionFlows(t *testing.T) {
 		store := newTestStore(t)
 		ctx := context.Background()
 
-		embedder := newPredictableEmbedder(3)
 		llm := &predictableLLM{
 			rubricResponse: goodRubricJSON(),
 			criticResponse: rejectVerdictJSON(),
 		}
 
 		s1 := extraction.NewStage1Filter(defaultExtractionConfig(), testLogger())
-		s2 := extraction.NewStage2Scorer(embedder, &mockQuerier{sim: 0.5}, llm, defaultExtractionConfig(), testLogger())
+		s2 := extraction.NewStage2Scorer(llm, defaultExtractionConfig(), testLogger())
 		s3 := extraction.NewStage3Critic(llm, defaultExtractionConfig(), testLogger())
 
 		pipeline, _ := extraction.NewPipeline(extraction.PipelineConfig{
@@ -189,43 +187,9 @@ func TestRejectionFlows(t *testing.T) {
 	})
 }
 
-func TestEmbeddingFailureDegradation(t *testing.T) {
+func TestInjectionDegradedModeNoEmbedder(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()
-
-	embedder := newPredictableEmbedder(3)
-	embedder.failAfter = -1
-
-	llm := &predictableLLM{
-		rubricResponse: goodRubricJSON(),
-		criticResponse: extractVerdictJSON(),
-	}
-
-	s1 := extraction.NewStage1Filter(defaultExtractionConfig(), testLogger())
-	s2 := extraction.NewStage2Scorer(embedder, &mockQuerier{sim: 0.5}, llm, defaultExtractionConfig(), testLogger())
-	s3 := extraction.NewStage3Critic(llm, defaultExtractionConfig(), testLogger())
-
-	pipeline, _ := extraction.NewPipeline(extraction.PipelineConfig{
-		Stage1: s1, Stage2: s2, Stage3: s3, Committer: noopCommitter{}, Log: testLogger(),
-	})
-
-	session := goodSession("sess-err-1", "test-lib")
-	result, err := pipeline.Extract(ctx, session, []byte("fix database issue"))
-
-	if err != nil {
-		t.Fatalf("pipeline returned error: %v", err)
-	}
-	if result.Status != model.StatusError {
-		t.Errorf("status = %q, want error", result.Status)
-	}
-	if result.Status == model.StatusError && result.Error == "" {
-		t.Error("expected error message in result")
-	}
-
-	results, _ := store.Query(ctx, storage.SkillQuery{LibraryIDs: []string{"test-lib"}, Limit: 10})
-	if len(results) != 0 {
-		t.Errorf("expected 0 skills after failure, got %d", len(results))
-	}
 
 	sk := &model.SkillRecord{
 		ID: "skill-fallback", Name: "fix-db", Version: 1, LibraryID: "test-lib",
@@ -283,7 +247,7 @@ func TestConcurrentExtractions(t *testing.T) {
 			}
 
 			s1 := extraction.NewStage1Filter(defaultExtractionConfig(), testLogger())
-			s2 := extraction.NewStage2Scorer(embedder, &mockQuerier{sim: 0.5}, llm, defaultExtractionConfig(), testLogger())
+			s2 := extraction.NewStage2Scorer(llm, defaultExtractionConfig(), testLogger())
 			s3 := extraction.NewStage3Critic(llm, defaultExtractionConfig(), testLogger())
 
 			indexer := storage.NewSQLiteIndexer(store)

--- a/tests/integration/extraction_integration_test.go
+++ b/tests/integration/extraction_integration_test.go
@@ -47,7 +47,6 @@ func TestPipelineWorkerConcurrentResults(t *testing.T) {
 
 	for i := 0; i < n; i++ {
 		go func(idx int) {
-			embedder := newPredictableEmbedder(3)
 			// Each gets a unique pattern to avoid duplicate skill names.
 			pattern := fmt.Sprintf("FIX/Backend/Issue%d", idx)
 			llm := &predictableLLM{
@@ -59,7 +58,7 @@ func TestPipelineWorkerConcurrentResults(t *testing.T) {
 			}
 
 			s1 := extraction.NewStage1Filter(defaultExtractionConfig(), testLogger())
-			s2 := extraction.NewStage2Scorer(embedder, &mockQuerier{sim: 0.5}, llm, defaultExtractionConfig(), testLogger())
+			s2 := extraction.NewStage2Scorer(llm, defaultExtractionConfig(), testLogger())
 			s3 := extraction.NewStage3Critic(llm, defaultExtractionConfig(), testLogger())
 
 			pipeline, _ := extraction.NewPipeline(extraction.PipelineConfig{
@@ -279,7 +278,6 @@ func TestImportDuplicateSession(t *testing.T) {
 func TestImportInvalidSessionLog(t *testing.T) {
 	_ = newTestStore(t)
 	ctx := context.Background()
-	embedder := newPredictableEmbedder(3)
 
 	llm := &predictableLLM{
 		rubricResponse: goodRubricJSON(),
@@ -287,7 +285,7 @@ func TestImportInvalidSessionLog(t *testing.T) {
 	}
 
 	s1 := extraction.NewStage1Filter(defaultExtractionConfig(), testLogger())
-	s2 := extraction.NewStage2Scorer(embedder, &mockQuerier{sim: 0.5}, llm, defaultExtractionConfig(), testLogger())
+	s2 := extraction.NewStage2Scorer(llm, defaultExtractionConfig(), testLogger())
 	s3 := extraction.NewStage3Critic(llm, defaultExtractionConfig(), testLogger())
 
 	pipeline, _ := extraction.NewPipeline(extraction.PipelineConfig{
@@ -556,7 +554,7 @@ func TestExtractThenInject(t *testing.T) {
 	}
 
 	s1 := extraction.NewStage1Filter(defaultExtractionConfig(), testLogger())
-	s2 := extraction.NewStage2Scorer(embedder, &mockQuerier{sim: 0.5}, llm, defaultExtractionConfig(), testLogger())
+	s2 := extraction.NewStage2Scorer(llm, defaultExtractionConfig(), testLogger())
 	s3 := extraction.NewStage3Critic(llm, defaultExtractionConfig(), testLogger())
 
 	indexer := storage.NewSQLiteIndexer(store)
@@ -997,13 +995,12 @@ func TestBug_SamplingCounterRace(t *testing.T) {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			embedder := newPredictableEmbedder(3)
 			llm := &predictableLLM{
 				rubricResponse: goodRubricJSON(),
 				criticResponse: extractVerdictJSON(),
 			}
 			s1 := extraction.NewStage1Filter(defaultExtractionConfig(), testLogger())
-			s2 := extraction.NewStage2Scorer(embedder, &mockQuerier{sim: 0.5}, llm, defaultExtractionConfig(), testLogger())
+			s2 := extraction.NewStage2Scorer(llm, defaultExtractionConfig(), testLogger())
 			s3 := extraction.NewStage3Critic(llm, defaultExtractionConfig(), testLogger())
 			pipeline, _ := extraction.NewPipeline(extraction.PipelineConfig{
 				Stage1: s1, Stage2: s2, Stage3: s3,
@@ -1040,14 +1037,13 @@ func TestWorkerPoolWithRealPipeline(t *testing.T) {
 	defer queueStore.Close()
 	q := queue.NewQueue(queueStore, tmpDir, cfg, testLogger())
 
-	embedder := newPredictableEmbedder(3)
 	llm := &predictableLLM{
 		rubricResponse: goodRubricJSON(),
 		criticResponse: extractVerdictJSON(),
 	}
 
 	s1 := extraction.NewStage1Filter(defaultExtractionConfig(), testLogger())
-	s2 := extraction.NewStage2Scorer(embedder, &mockQuerier{sim: 0.5}, llm, defaultExtractionConfig(), testLogger())
+	s2 := extraction.NewStage2Scorer(llm, defaultExtractionConfig(), testLogger())
 	s3 := extraction.NewStage3Critic(llm, defaultExtractionConfig(), testLogger())
 
 	pipeline, _ := extraction.NewPipeline(extraction.PipelineConfig{

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -122,14 +122,6 @@ func (e *predictableEmbedder) deterministicVector(text string) []float32 {
 
 // --- Mock SkillQuerier (for Stage2) ---
 
-type mockQuerier struct {
-	sim float64
-}
-
-func (m *mockQuerier) QueryNearest(_ context.Context, _ []float32, _ string) (*model.SkillQueryResult, error) {
-	return &model.SkillQueryResult{CosineSim: m.sim}, nil
-}
-
 // --- Mock HumanReviewWriter ---
 
 type mockReviewWriter struct {


### PR DESCRIPTION
## What

Removes the embedding novelty check from Stage 2 of the extraction pipeline. Stage 2 was embedding **raw session logs** and comparing against skill embeddings — different content types, meaningless similarity scores.

## Why

Embedding novelty should only compare skill-to-skill vectors, not session-to-skill. The novelty check in `publish()` already does this correctly on the extracted SKILL.md content.

## Changes

- **Stage 2** now only does LLM rubric scoring (no embedding, no querier)
- Removed `EmbeddingDistance`, `NoveltyScore`, `NearestSkillName` from `Stage2Result`
- Removed `embedder` and `querier` params from `NewStage2Scorer()`
- Updated all callers (CLI commands, tests)
- Renamed `TestEmbeddingFailureDegradation` → `TestInjectionDegradedModeNoEmbedder` (test was testing obsolete behavior)
- Net -329 lines

## Pipeline flow (after)

1. **Stage 1** — metadata filter (free)
2. **Stage 2** — LLM rubric scoring (one LLM call)
3. **Stage 3** — LLM critic + skill extraction (one LLM call, produces SKILL.md)
4. **Novelty check** — on extracted skill body via `NoveltyClient.Check()` (correct: skill-to-skill comparison)