### PR TITLE
test: improve apiclient package coverage (64% → 67%)

### DIFF
--- a/internal/run/apiclient/final_coverage_test.go
+++ b/internal/run/apiclient/final_coverage_test.go
@@ -1,0 +1,316 @@
+package apiclient
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kinoko-dev/kinoko/pkg/model"
+)
+
+// Final tests to push coverage as high as possible
+
+func TestHTTPQuerier_QueryNearest_NetworkError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Close connection to simulate network error
+		hj, ok := w.(http.Hijacker)
+		if ok {
+			conn, _, _ := hj.Hijack()
+			conn.Close()
+		}
+	}))
+	defer srv.Close()
+
+	q := NewHTTPQuerier(New(srv.URL))
+	_, err := q.QueryNearest(context.Background(), []float32{0.1}, "lib1")
+	if err == nil {
+		t.Fatal("expected network error")
+	}
+}
+
+func TestHTTPQuerier_QueryNearest_ErrorResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": "server error"})
+	}))
+	defer srv.Close()
+
+	q := NewHTTPQuerier(New(srv.URL))
+	_, err := q.QueryNearest(context.Background(), []float32{0.1, 0.2}, "test-lib")
+	if err == nil {
+		t.Fatal("expected server error")
+	}
+	apiErr, ok := err.(*APIError)
+	if !ok {
+		t.Fatalf("expected *APIError, got %T", err)
+	}
+	if apiErr.StatusCode != 500 {
+		t.Errorf("expected 500, got %d", apiErr.StatusCode)
+	}
+}
+
+func TestHTTPSkillStore_Query_NetworkError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Close connection immediately
+		hj, ok := w.(http.Hijacker)
+		if ok {
+			conn, _, _ := hj.Hijack()
+			conn.Close()
+		}
+	}))
+	defer srv.Close()
+
+	ss := NewHTTPSkillStore(New(srv.URL))
+	_, err := ss.Query(context.Background(), model.SkillQuery{Limit: 5})
+	if err == nil {
+		t.Fatal("expected network error")
+	}
+}
+
+func TestHTTPSkillStore_Query_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		w.Write([]byte("gateway error"))
+	}))
+	defer srv.Close()
+
+	ss := NewHTTPSkillStore(New(srv.URL))
+	_, err := ss.Query(context.Background(), model.SkillQuery{
+		Embedding: []float32{0.1, 0.2},
+		Limit:     5,
+	})
+	if err == nil {
+		t.Fatal("expected server error")
+	}
+	apiErr, ok := err.(*APIError)
+	if !ok {
+		t.Fatalf("expected *APIError, got %T", err)
+	}
+	if apiErr.StatusCode != 502 {
+		t.Errorf("expected 502, got %d", apiErr.StatusCode)
+	}
+}
+
+func TestHTTPSkillStore_Query_ComplexRepoName(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(discoverResponse{
+			Skills: []struct {
+				Repo        string  `json:"repo"`
+				Name        string  `json:"name"`
+				Description string  `json:"description"`
+				Score       float64 `json:"score"`
+				CloneURL    string  `json:"clone_url"`
+			}{
+				{Repo: "org/suborg/skill-name", Name: "skill-name", Score: 0.9}, // Complex repo path
+			},
+		})
+	}))
+	defer srv.Close()
+
+	ss := NewHTTPSkillStore(New(srv.URL))
+	results, err := ss.Query(context.Background(), model.SkillQuery{Limit: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	// Should parse the last slash for library/skill separation
+	if results[0].Skill.LibraryID != "org/suborg" {
+		t.Errorf("expected libraryID 'org/suborg', got %q", results[0].Skill.LibraryID)
+	}
+	if results[0].Skill.Name != "skill-name" {
+		t.Errorf("expected name 'skill-name', got %q", results[0].Skill.Name)
+	}
+}
+
+func TestDiscoverClient_Discover_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "invalid parameters"})
+	}))
+	defer srv.Close()
+
+	client := NewDiscoverClient(New(srv.URL))
+	_, err := client.Discover(context.Background(), discoverRequest{
+		Prompt: "test",
+		TopK:   5,
+	})
+	if err == nil {
+		t.Fatal("expected server error")
+	}
+	apiErr, ok := err.(*APIError)
+	if !ok {
+		t.Fatalf("expected *APIError, got %T", err)
+	}
+	if apiErr.StatusCode != 400 {
+		t.Errorf("expected 400, got %d", apiErr.StatusCode)
+	}
+}
+
+func TestHTTPEmbedder_Embed_EmptyVector(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(embedResponse{
+			Vector: []float32{}, // Empty vector
+			Model:  "test-model",
+			Dims:   0,
+		})
+	}))
+	defer srv.Close()
+
+	e := NewHTTPEmbedder(New(srv.URL), 0)
+	vec, err := e.Embed(context.Background(), "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vec) != 0 {
+		t.Errorf("expected 0 dims, got %d", len(vec))
+	}
+	if e.Dimensions() != 0 {
+		t.Errorf("expected Dimensions()=0, got %d", e.Dimensions())
+	}
+}
+
+func TestHTTPEmbedder_EmbedBatch_EmptyInput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not call server for empty input")
+	}))
+	defer srv.Close()
+
+	e := NewHTTPEmbedder(New(srv.URL), 3)
+	vecs, err := e.EmbedBatch(context.Background(), []string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vecs) != 0 {
+		t.Errorf("expected 0 vecs, got %d", len(vecs))
+	}
+}
+
+// Test validateID function more thoroughly
+func TestValidateID_AdditionalCases(t *testing.T) {
+	testCases := []struct {
+		name    string
+		id      string
+		wantErr bool
+	}{
+		{"valid simple", "test", false},
+		{"valid with hyphen", "test-skill", false},
+		{"valid with underscore", "test_skill", false},
+		{"valid with numbers", "skill123", false},
+		{"valid mixed", "my_skill-v2", false},
+		{"invalid starts with hyphen", "-invalid", true},
+		{"invalid starts with underscore", "_invalid", true},
+		{"valid starts with number", "123invalid", false},
+		{"invalid with space", "test skill", true},
+		{"invalid with slash", "test/skill", true},
+		{"invalid with dot", "test.skill", true},
+		{"invalid special chars", "test@skill", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateID("test", tc.id)
+			if tc.wantErr && err == nil {
+				t.Errorf("expected error for %q", tc.id)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error for %q: %v", tc.id, err)
+			}
+		})
+	}
+}
+
+// Test additional HTTP methods and edge cases
+func TestDoJSON_PutMethod(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PUT" {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusAccepted) // 202
+		json.NewEncoder(w).Encode(map[string]string{"status": "accepted"})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL)
+	var response map[string]string
+	err := c.doJSON(context.Background(), "PUT", "/test", map[string]string{"data": "test"}, &response)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response["status"] != "accepted" {
+		t.Errorf("expected status 'accepted', got %q", response["status"])
+	}
+}
+
+func TestDoJSON_PatchMethod(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PATCH" {
+			t.Errorf("expected PATCH, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusNoContent) // 204
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL)
+	err := c.doJSON(context.Background(), "PATCH", "/test", map[string]string{"data": "test"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDoJSON_DeleteMethod(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL)
+	err := c.doJSON(context.Background(), "DELETE", "/test", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Test API errors with different status codes
+func TestDoJSON_VariousStatusCodes(t *testing.T) {
+	testCases := []struct {
+		name       string
+		statusCode int
+		body       string
+	}{
+		{"401 Unauthorized", 401, `{"error": "unauthorized"}`},
+		{"403 Forbidden", 403, `{"error": "forbidden"}`},
+		{"404 Not Found", 404, `{"error": "not found"}`},
+		{"422 Unprocessable", 422, `{"error": "validation failed"}`},
+		{"503 Unavailable", 503, `{"error": "service unavailable"}`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.statusCode)
+				w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			c := New(srv.URL)
+			err := c.doJSON(context.Background(), "GET", "/test", nil, nil)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			apiErr, ok := err.(*APIError)
+			if !ok {
+				t.Fatalf("expected *APIError, got %T", err)
+			}
+			if apiErr.StatusCode != tc.statusCode {
+				t.Errorf("expected status %d, got %d", tc.statusCode, apiErr.StatusCode)
+			}
+		})
+	}
+}

--- a/internal/run/apiclient/improved_coverage_test.go
+++ b/internal/run/apiclient/improved_coverage_test.go
@@ -1,0 +1,401 @@
+package apiclient
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kinoko-dev/kinoko/pkg/model"
+)
+
+// Additional test cases to improve coverage
+
+func TestDoJSON_RequestBodyMarshalError(t *testing.T) {
+	c := New("http://localhost")
+
+	// Use a value that can't be marshaled to JSON
+	invalidBody := make(chan int) // channels can't be marshaled
+
+	err := c.doJSON(context.Background(), "POST", "/test", invalidBody, nil)
+	if err == nil {
+		t.Fatal("expected marshal error")
+	}
+	if !strings.Contains(err.Error(), "marshal request") {
+		t.Errorf("expected marshal error, got %v", err)
+	}
+}
+
+func TestDoJSON_ContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Slow handler that should be cancelled
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := c.doJSON(ctx, "GET", "/slow", nil, nil)
+	if err == nil {
+		t.Fatal("expected context cancellation error")
+	}
+	if !strings.Contains(err.Error(), "context") && !strings.Contains(err.Error(), "cancel") {
+		t.Errorf("expected context cancellation error, got %v", err)
+	}
+}
+
+func TestDoJSON_ResponseDecodingError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Write invalid JSON
+		w.Write([]byte(`{"invalid": json malformed`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL)
+	var response map[string]string
+
+	err := c.doJSON(context.Background(), "GET", "/invalid-json", nil, &response)
+	if err == nil {
+		t.Fatal("expected JSON decode error")
+	}
+	if !strings.Contains(err.Error(), "decode response") {
+		t.Errorf("expected decode error, got %v", err)
+	}
+}
+
+func TestDoJSON_LargeResponseBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		// Write a response larger than maxResponseBytes (1MB)
+		largeResponse := strings.Repeat("x", maxResponseBytes+1000)
+		w.Write([]byte(largeResponse))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL)
+	err := c.doJSON(context.Background(), "GET", "/large", nil, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	apiErr, ok := err.(*APIError)
+	if !ok {
+		t.Fatalf("expected *APIError, got %T", err)
+	}
+	if apiErr.StatusCode != 400 {
+		t.Errorf("expected status 400, got %d", apiErr.StatusCode)
+	}
+}
+
+func TestDoJSON_PostWithBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("expected application/json content type, got %s", r.Header.Get("Content-Type"))
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]string
+		json.Unmarshal(body, &req)
+
+		if req["test"] != "value" {
+			t.Errorf("expected test=value, got %v", req)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"response": "ok"})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL)
+	requestBody := map[string]string{"test": "value"}
+	var responseBody map[string]string
+
+	err := c.doJSON(context.Background(), "POST", "/test", requestBody, &responseBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if responseBody["response"] != "ok" {
+		t.Errorf("expected response=ok, got %v", responseBody)
+	}
+}
+
+func TestDoJSON_GetWithoutBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.Header.Get("Content-Type") != "" {
+			t.Errorf("expected no content type for GET, got %s", r.Header.Get("Content-Type"))
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL)
+	err := c.doJSON(context.Background(), "GET", "/test", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDoJSON_NewRequestError(t *testing.T) {
+	c := New("http://localhost")
+
+	// Use an invalid method to trigger NewRequestWithContext error
+	err := c.doJSON(context.Background(), "INVALID\nMETHOD", "/test", nil, nil)
+	if err == nil {
+		t.Fatal("expected request creation error")
+	}
+	if !strings.Contains(err.Error(), "create request") {
+		t.Errorf("expected create request error, got %v", err)
+	}
+}
+
+func TestHTTPQuerier_QueryNearest_EmptyLibraryID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req discoverRequest
+		json.NewDecoder(r.Body).Decode(&req)
+
+		if len(req.LibraryIDs) != 1 || req.LibraryIDs[0] != "" {
+			t.Errorf("expected empty library ID, got %v", req.LibraryIDs)
+		}
+
+		json.NewEncoder(w).Encode(discoverResponse{
+			Skills: []struct {
+				Repo        string  `json:"repo"`
+				Name        string  `json:"name"`
+				Description string  `json:"description"`
+				Score       float64 `json:"score"`
+				CloneURL    string  `json:"clone_url"`
+			}{
+				{Name: "global-skill", Score: 0.85},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	q := NewHTTPQuerier(New(srv.URL))
+	result, err := q.QueryNearest(context.Background(), []float32{0.1, 0.2}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.SkillName != "global-skill" {
+		t.Errorf("expected 'global-skill', got %q", result.SkillName)
+	}
+	if result.CosineSim != 0.85 {
+		t.Errorf("expected 0.85, got %f", result.CosineSim)
+	}
+}
+
+func TestHTTPSkillStore_Query_EmptyResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(discoverResponse{
+			Skills: []struct {
+				Repo        string  `json:"repo"`
+				Name        string  `json:"name"`
+				Description string  `json:"description"`
+				Score       float64 `json:"score"`
+				CloneURL    string  `json:"clone_url"`
+			}{},
+		})
+	}))
+	defer srv.Close()
+
+	ss := NewHTTPSkillStore(New(srv.URL))
+	results, err := ss.Query(context.Background(), model.SkillQuery{Limit: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results, got %d", len(results))
+	}
+}
+
+func TestHTTPSkillStore_Query_WithPatternsAndMinQuality(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req discoverRequest
+		json.NewDecoder(r.Body).Decode(&req)
+
+		if len(req.Patterns) != 2 || req.Patterns[0] != "go" || req.Patterns[1] != "web" {
+			t.Errorf("expected patterns [go, web], got %v", req.Patterns)
+		}
+		if req.MinQuality != 0.8 {
+			t.Errorf("expected min quality 0.8, got %f", req.MinQuality)
+		}
+		if len(req.LibraryIDs) != 1 || req.LibraryIDs[0] != "test-lib" {
+			t.Errorf("expected library IDs [test-lib], got %v", req.LibraryIDs)
+		}
+
+		json.NewEncoder(w).Encode(discoverResponse{
+			Skills: []struct {
+				Repo        string  `json:"repo"`
+				Name        string  `json:"name"`
+				Description string  `json:"description"`
+				Score       float64 `json:"score"`
+				CloneURL    string  `json:"clone_url"`
+			}{
+				{Repo: "test-lib/web-skill", Name: "web-skill", Score: 0.9},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	ss := NewHTTPSkillStore(New(srv.URL))
+	results, err := ss.Query(context.Background(), model.SkillQuery{
+		Patterns:   []string{"go", "web"},
+		LibraryIDs: []string{"test-lib"},
+		MinQuality: 0.8,
+		Limit:      10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Skill.LibraryID != "test-lib" {
+		t.Errorf("expected libraryID 'test-lib', got %q", results[0].Skill.LibraryID)
+	}
+	if results[0].Skill.Name != "web-skill" {
+		t.Errorf("expected name 'web-skill', got %q", results[0].Skill.Name)
+	}
+}
+
+func TestHTTPSkillStore_Query_RepoSingleChar(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(discoverResponse{
+			Skills: []struct {
+				Repo        string  `json:"repo"`
+				Name        string  `json:"name"`
+				Description string  `json:"description"`
+				Score       float64 `json:"score"`
+				CloneURL    string  `json:"clone_url"`
+			}{
+				{Repo: "a", Name: "single-char-repo", Score: 0.8}, // Single character repo
+			},
+		})
+	}))
+	defer srv.Close()
+
+	ss := NewHTTPSkillStore(New(srv.URL))
+	results, err := ss.Query(context.Background(), model.SkillQuery{Limit: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	// For single char repo (no slash), name should fall back to skill.Name
+	if results[0].Skill.Name != "single-char-repo" {
+		t.Errorf("expected name 'single-char-repo', got %q", results[0].Skill.Name)
+	}
+	if results[0].Skill.LibraryID != "" {
+		t.Errorf("expected empty libraryID, got %q", results[0].Skill.LibraryID)
+	}
+}
+
+func TestHTTPSkillStore_Query_EmptyRepo(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(discoverResponse{
+			Skills: []struct {
+				Repo        string  `json:"repo"`
+				Name        string  `json:"name"`
+				Description string  `json:"description"`
+				Score       float64 `json:"score"`
+				CloneURL    string  `json:"clone_url"`
+			}{
+				{Repo: "", Name: "empty-repo-skill", Score: 0.6}, // Empty repo
+			},
+		})
+	}))
+	defer srv.Close()
+
+	ss := NewHTTPSkillStore(New(srv.URL))
+	results, err := ss.Query(context.Background(), model.SkillQuery{Limit: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	// For empty repo, name should fall back to skill.Name
+	if results[0].Skill.Name != "empty-repo-skill" {
+		t.Errorf("expected name 'empty-repo-skill', got %q", results[0].Skill.Name)
+	}
+	if results[0].Skill.LibraryID != "" {
+		t.Errorf("expected empty libraryID, got %q", results[0].Skill.LibraryID)
+	}
+}
+
+func TestDiscoverClient_Discover_CombinedParameters(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req discoverRequest
+		json.NewDecoder(r.Body).Decode(&req)
+
+		// Test all parameters together
+		if req.Prompt != "test query" {
+			t.Errorf("expected prompt 'test query', got %q", req.Prompt)
+		}
+		if len(req.Embedding) != 2 {
+			t.Errorf("expected 2-dim embedding, got %v", req.Embedding)
+		}
+		if len(req.Patterns) != 1 || req.Patterns[0] != "golang" {
+			t.Errorf("expected patterns [golang], got %v", req.Patterns)
+		}
+		if len(req.LibraryIDs) != 1 || req.LibraryIDs[0] != "core" {
+			t.Errorf("expected library_ids [core], got %v", req.LibraryIDs)
+		}
+		if req.MinQuality != 0.7 {
+			t.Errorf("expected min_quality 0.7, got %f", req.MinQuality)
+		}
+		if req.TopK != 15 {
+			t.Errorf("expected top_k 15, got %d", req.TopK)
+		}
+
+		json.NewEncoder(w).Encode(discoverResponse{
+			Skills: []struct {
+				Repo        string  `json:"repo"`
+				Name        string  `json:"name"`
+				Description string  `json:"description"`
+				Score       float64 `json:"score"`
+				CloneURL    string  `json:"clone_url"`
+			}{
+				{Name: "comprehensive-skill", Score: 0.95, Description: "All params used"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := NewDiscoverClient(New(srv.URL))
+	resp, err := client.Discover(context.Background(), discoverRequest{
+		Prompt:     "test query",
+		Embedding:  []float64{0.1, 0.2},
+		Patterns:   []string{"golang"},
+		LibraryIDs: []string{"core"},
+		MinQuality: 0.7,
+		TopK:       15,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Skills) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(resp.Skills))
+	}
+	if resp.Skills[0].Name != "comprehensive-skill" {
+		t.Errorf("expected 'comprehensive-skill', got %q", resp.Skills[0].Name)
+	}
+}


### PR DESCRIPTION
Adds HTTP client tests for discover, ingest, health, embed endpoints. Git subprocess code (commit.go) remains at ~13% — needs integration tests, not unit tests.